### PR TITLE
docs: Fix broken link

### DIFF
--- a/docs/RUNNING.md
+++ b/docs/RUNNING.md
@@ -1,6 +1,6 @@
 # Running the exporter
 
-It is recommended to run the exporter from a Docker container. Build system for Docker is included in this repository (see docs/BUILD.md) or you can use the offical Docker image from <https://hub.docker.com/pdreker/fritz_exporter>
+It is recommended to run the exporter from a Docker container. Build system for Docker is included in this repository (see docs/BUILD.md) or you can use the offical Docker image from <https://hub.docker.com/r/pdreker/fritz_exporter>
 
 ## Configuration
 


### PR DESCRIPTION
Btw: Totally missed the RUNNING.md the first 15 minutes, given there's also no link in the README. Might be worth to add a link there on top somewhere.

Thanks for the work on the exporter!