### PR TITLE
Move to Multi-Tag docker builds

### DIFF
--- a/.github/workflows/build-and-push-release.yaml
+++ b/.github/workflows/build-and-push-release.yaml
@@ -23,6 +23,10 @@ jobs:
           release_branch: master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          fetch-depth: 0
       - name: generate docker tags
         id: meta
         uses: docker/metadata-action@v4
@@ -34,10 +38,6 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=raw,value=latest
-      - uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"

--- a/.github/workflows/build-and-push-release.yaml
+++ b/.github/workflows/build-and-push-release.yaml
@@ -23,6 +23,17 @@ jobs:
           release_branch: master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: generate docker tags
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
@@ -62,11 +73,9 @@ jobs:
           username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB }}
       - name: Build and push
-        env:
-          TAG: ${{ steps.update_semver.outputs.tag }}
         uses: docker/build-push-action@v3
         with:
           push: true
           context: .
           platforms: linux/arm/v6,linux/arm/v7,linux/amd64,linux/arm64/v8
-          tags: ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE }}:${{ env.TAG }}
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build-and-push-release.yaml
+++ b/.github/workflows/build-and-push-release.yaml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-      - name: Run image
+      - name: Setup poetry
         uses: abatilo/actions-poetry@v2
         with:
           poetry-version: 1.2.1
@@ -38,12 +38,11 @@ jobs:
         run: |
           V_VERSION=${{ steps.update_semver.outputs.tag }}
           poetry version "${V_VERSION//v/}"
-          poetry lock --no-update
       - name: Commit pyproject.toml back to repo
         run: |
           git config --local user.name github-actions
           git config --local user.email github-actions@github.com
-          git add pyproject.toml poetry.lock
+          git add pyproject.toml
           git commit -m "Update pyproject.toml for version ${{ steps.update_semver.outputs.tag }}"
       - name: Push pyproject.toml back to master
         uses: ad-m/github-push-action@master

--- a/.github/workflows/build-and-push-release.yaml
+++ b/.github/workflows/build-and-push-release.yaml
@@ -49,11 +49,15 @@ jobs:
         run: |
           V_VERSION=${{ steps.update_semver.outputs.tag }}
           poetry version "${V_VERSION//v/}"
-      - name: Commit pyproject.toml back to repo
+      - name: Update Helm Chart.yaml
+        uses: mikefarah/yq@v4.27.5
+        with:
+          cmd: yq '.appVersion = "${{ steps.update_semver.outputs.tag }}"' -i helm/fritz-exporter/Chart.yaml
+      - name: Commit pyproject.toml and Chart.yaml back to repo
         run: |
           git config --local user.name github-actions
           git config --local user.email github-actions@github.com
-          git add pyproject.toml
+          git add pyproject.toml helm/fritz-exporter/Chart.yaml
           git commit -m "Update pyproject.toml for version ${{ steps.update_semver.outputs.tag }}"
       - name: Push pyproject.toml back to master
         uses: ad-m/github-push-action@master

--- a/docs/docker-images.rst
+++ b/docs/docker-images.rst
@@ -6,17 +6,25 @@ Docker images for this exporter are available from `Docker Hub <https://hub.dock
 Tags
 ----
 
-+----------+----------------------------------------------------------------------------------+
-| Tag      | Description                                                                      |
-+==========+==================================================================================+
-| develop  | Latest build from develop branch. **This may be unstable and change at any       |
-|          | time without notice or regards for compatibility!**                              |
-+----------+----------------------------------------------------------------------------------+
-| latest   | Latest released version. This might automatically upgrade through major          |
-|          | releases, which may be incompatible with currently running versions.             |
-|          | Can be used, if you don't mind the occasional breakage. Major releases are rare. |
-+----------+----------------------------------------------------------------------------------+
-| Version  | Specific released versions. Will not update your images without you explicity    |
-| (e.g.    | changing the image tag in Docker. Currently recommended.                         |
-| v2.1.1)  |                                                                                  |
-+----------+----------------------------------------------------------------------------------+
++----------------+----------------------------------------------------------------------------------+
+| Tag            | Description                                                                      |
++================+==================================================================================+
+| develop        | Latest build from develop branch. **This may be unstable and change at any       |
+|                | time without notice or regards for compatibility!**                              |
++----------------+----------------------------------------------------------------------------------+
+| latest         | Latest released version. This might automatically upgrade through major          |
+|                | releases, which may be incompatible with currently running versions.             |
+|                | Can be used, if you don't mind the occasional breakage. Major releases are rare. |
++----------------+----------------------------------------------------------------------------------+
+| full version   | Specific released versions. Will not update your images without you explicity    |
+| (e.g.          | changing the image tag in Docker.                                                |
+| 2.1.1)         |                                                                                  |
++----------------+----------------------------------------------------------------------------------+
+| major          | Specific major version. E.g. "2" will install any 2.x.y release thus             |
+| (e.g. "2")     | avoiding unexpected major upgrades which may be incompatible or contain          |
+|                | breaking changes. **Recommended**                                                |
++----------------+----------------------------------------------------------------------------------+
+| major.minor    | Specific major/minor version. E.g. "2.1" will install the latest 2.1.x release   |
+| (e.g. 2.1)     | thus avoiding unexpected major upgrades which may be incompatible or contain     |
+|                | breaking changes. This will effectively only update patch releases.              |
++----------------+----------------------------------------------------------------------------------+

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -19,7 +19,7 @@ Create an empty directory ``fritz-exporter`` and place a file ``docker-compose.y
   version: "3.8"
   services:
     fritz-exporter:
-      image: pdreker/fritz_exporter:v2.1.1
+      image: pdreker/fritz_exporter:2
       container_name: fritz-exporter
       restart: unless-stopped
       environment:

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -39,7 +39,7 @@ To run the exporter from docker-compose create an empty directory ``fritz-export
   version: "3.8"
   services:
     fritz-exporter:
-      image: pdreker/fritz_exporter:latest
+      image: pdreker/fritz_exporter:2
       container_name: fritz-exporter
       restart: always
       environment:
@@ -61,7 +61,7 @@ Create an empty directory ``fritz-exporter`` and put a file ``docker-compose.yml
   version: "3.8"
   services:
     fritz-exporter:
-      image: pdreker/fritz_exporter:latest
+      image: pdreker/fritz_exporter:2
       command: --config /fritz-exporter.yml
       build: ../
       container_name: fritz-exporter

--- a/helm/fritz-exporter/Chart.yaml
+++ b/helm/fritz-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: fritz-exporter
 description: fritz-exporter Helm Chart
 type: application
 version: 0.1.0
-appVersion: "v2.1.0"
+appVersion: "v2.1.2"
 maintainers:
   - email: patrick@dreker.de
     name: Patrick Dreker


### PR DESCRIPTION
No functional or code changes.

* Enable multiple docker tags for releaes (latest, 2, 2.1, 2.1.3, ...
* Automatically bump appVersion in Helm Chart.yaml