### PR TITLE
fix: a lot duplicate metrics when FRITZ_HOST_INFO is enabled

### DIFF
--- a/.github/workflows/build-trunk.yaml
+++ b/.github/workflows/build-trunk.yaml
@@ -8,7 +8,7 @@ env:
   DOCKER_REGISTRY_USERNAME: pdreker
   DOCKER_REGISTRY_REPO: pdreker
   DOCKER_REGISTRY_IMAGE: fritz_exporter
-  DOCKER_REGISTRY_HOST: hub.docker.com
+  DOCKER_REGISTRY_HOST: docker.io
   POETRY_VERSION: 1.2.2
 
 jobs:

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -6,7 +6,7 @@ env:
   DOCKER_REGISTRY_USERNAME: pdreker
   DOCKER_REGISTRY_REPO: pdreker
   DOCKER_REGISTRY_IMAGE: fritz_exporter
-  DOCKER_REGISTRY_HOST: hub.docker.com
+  DOCKER_REGISTRY_HOST: docker.io
   POETRY_VERSION: 1.2.2
 
 jobs:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -3,11 +3,7 @@ name: Run Tests
 on:
   pull_request:
     branches:
-      - develop
-      - master
-  push:
-    branches:
-      - develop
+      - main
 
 jobs:
   run-checks:

--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -862,8 +862,8 @@ class HostInfo(FritzCapability):
                 ],
                 host_speed,
             )
-            yield self.metrics["hostactive"]
-            yield self.metrics["hostspeed"]
+        yield self.metrics["hostactive"]
+        yield self.metrics["hostspeed"]
 
 
 # Copyright 2019-2022 Patrick Dreker <patrick@dreker.de>


### PR DESCRIPTION
Fixes #115

Due a wrong indentation the the metrics for host_info were repeatedly delivered in every query causing a quadratic increase in output size over the number of hosts reported by the Fritz device.

This does not improve performance for host_info metrics, but massively reduces the amount of data delivered by the exporter.