### PR TITLE
fix: exporter does not honor log_level from config file.

### DIFF
--- a/fritzexporter/__main__.py
+++ b/fritzexporter/__main__.py
@@ -28,7 +28,6 @@ def main():
     levels = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
     parser.add_argument(
         "--log-level",
-        default="INFO",
         choices=levels,
         help="Set log-level (default: INFO)",
     )
@@ -67,6 +66,9 @@ def main():
     log_level = (
         getattr(logging, args.log_level) if args.log_level else getattr(logging, config.log_level)
     )
+    if not log_level:
+        log_level = "INFO"
+
     loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict]
     for log in loggers:
         log.setLevel(log_level)


### PR DESCRIPTION
Fixes #116

Refactoring of Config logic introduced a logic error, where the exporter would *always* use the default log_level, if none was specified in the command line arguments.