### PR TITLE
build: do not autobuild trunk

### DIFF
--- a/.github/workflows/build-trunk.yaml
+++ b/.github/workflows/build-trunk.yaml
@@ -1,8 +1,6 @@
 name: Build and Push Trunk
 
-on:
-  push:
-    branches: [main]
+on: workflow_dispatch
 
 env:
   DOCKER_REGISTRY_USERNAME: pdreker


### PR DESCRIPTION
Do not automatically build a pre-release image from trunk: this eats quite some time and building locally for development is trvial. Also avoids polluting the changelogs with repeated merges to trunk.