### PR TITLE
Fixes for the helm chart

### DIFF
--- a/helm/fritz-exporter/templates/secret.yaml
+++ b/helm/fritz-exporter/templates/secret.yaml
@@ -5,4 +5,4 @@ metadata:
   labels:
     {{- include "fritz-exporter.labels" . | nindent 4 }}
 data:
-  config.yaml: {{ .Values.config | b64enc }}
+  config.yaml: {{ .Values.config | toYaml | b64enc }}

--- a/helm/fritz-exporter/templates/servicemonitor.yaml
+++ b/helm/fritz-exporter/templates/servicemonitor.yaml
@@ -31,6 +31,5 @@ spec:
       - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: fritz-exporter
-      app.kubernetes.io/instance: fritz
+      {{- include "fritz-exporter.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/helm/fritz-exporter/values.yaml
+++ b/helm/fritz-exporter/values.yaml
@@ -32,7 +32,7 @@ fullnameOverride: ""
 serviceMonitor:
   enabled: true
   namespace: ""
-  interval: 60
+  interval: 60s
   scrapeTimeout: 30s
   relabelings: ""
   metricRelabelings: ""


### PR DESCRIPTION
Hey, thanks for this tool and the grafana dashboard.

I deployed the exporter with the helm chart in this repository, but had some problems.

* The scraping interval is an integer and not a string.
* The selectorLabels on the ServiceMonitor can be wrong. The variable should be used, like in the other manifests.
* If the `config` value is not written as a string it can't be converted to base64. But the map can be converted to a yaml string.