### PR TITLE
fix: catch FritzArgumentError in capability scan

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,9 @@
         "--cov-branch",
         "--cov-config",
         ".coveragerc"
-    ]
+    ],
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter"
+    },
+    "python.formatting.provider": "none"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,3 +54,6 @@ flake8-comprehensions = "^3.10.0"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.black]
+line-length = 100


### PR DESCRIPTION
When checking for capabilities fritzconnection may return FritzArgumentError which needs to be caught.

Fixes #203
