### PR TITLE
docs(homeauto): explicitly mention missing metrics

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -61,7 +61,7 @@ The following groups of metrics are currently available:
 * PPP statistics
 * WiFi statistics
 * WAN Layer1 (physical link) statistics
-* Home Automation Devices (The TR-064 API is currently limited to switches, heating valves, temperatures and power meters - maybe AVM updates this in the future)
+* Home Automation Devices (The TR-064 API is currently limited to switches, heating valves, temperatures and power meters - maybe AVM updates this in the future. Especially windows sensors (open/closed) and the battery status of the devices are currently not reported due to these values simply not being reported by the device.)
 
 If there is any information missing or not displayed on your specific device, please open an issue on GitHub.
 


### PR DESCRIPTION
Fritz!OS currently does not report the state of window sensors or the battery state of any device via the TR-064 API.