### PR TITLE
Refactor/linting with ruff

### DIFF
--- a/fritz_export_helper.py
+++ b/fritz_export_helper.py
@@ -25,7 +25,7 @@ try:
         result = fc.call_action(args.service, args.action, arguments=arguments)
     else:
         result = fc.call_action(args.service, args.action)
-    print("--------------------------------\nRESULT:")
-    pprint(result)
+    print("--------------------------------\nRESULT:")  # noqa: T201
+    pprint(result)  # noqa: T203
 except (ServiceError, ActionError, FritzInternalError) as e:
-    print(f"Calling service {args.service} with action {args.action} returned an error: {e}")
+    print(f"Calling service {args.service} with action {args.action} returned an error: {e}")  # noqa: T201

--- a/fritz_export_helper.py
+++ b/fritz_export_helper.py
@@ -1,8 +1,9 @@
 import argparse
-from fritzconnection import FritzConnection
-from fritzconnection.core.exceptions import ActionError, ServiceError, FritzInternalError
-from pprint import pprint
 import json
+from pprint import pprint
+
+from fritzconnection import FritzConnection
+from fritzconnection.core.exceptions import ActionError, FritzInternalError, ServiceError
 
 parser = argparse.ArgumentParser(
     description="Check actions against Fritz TR-064 API and pretty print the results."

--- a/fritzexporter/__main__.py
+++ b/fritzexporter/__main__.py
@@ -9,7 +9,7 @@ from prometheus_client.core import REGISTRY
 
 from fritzexporter.config import ExporterException, get_config
 from fritzexporter.data_donation import donate_data
-from fritzexporter.fritzdevice import FritzCollector, FritzDevice
+from fritzexporter.fritzdevice import FritzCollector, FritzCredentials, FritzDevice
 
 from . import __version__
 
@@ -21,7 +21,7 @@ logger = logging.getLogger("fritzexporter")
 logger.addHandler(ch)
 
 
-def parse_cmdline():
+def parse_cmdline() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=f"Fritz Exporter for Prometheus using the TR-064 API (v{__version__})"
     )
@@ -63,19 +63,19 @@ def parse_cmdline():
     return parser.parse_args()
 
 
-def main():
+def main() -> None:
     fritzcollector = FritzCollector()
 
     args = parse_cmdline()
 
     if args.version:
-        print(__version__)
+        print(__version__)  # noqa: T201
         sys.exit(0)
 
     try:
         config = get_config(args.config)
-    except ExporterException as e:
-        logger.exception(e)
+    except ExporterException:
+        logger.exception("Error while reading config:")
         sys.exit(1)
 
     log_level = (
@@ -90,27 +90,25 @@ def main():
 
     for dev in config.devices:
         fritz_device = FritzDevice(
-            dev.hostname,
-            dev.username,
-            dev.password,
+            FritzCredentials(dev.hostname, dev.username, dev.password),
             dev.name,
-            dev.host_info,
+            host_info=dev.host_info,
         )
 
         if args.donate_data == "donate":
             donate_data(
                 fritz_device,
-                upload=True if args.upload_data == "upload" else False,
+                upload=args.upload_data == "upload",
                 sanitation=args.sanitize,
             )
             sys.exit(0)
         else:
-            logger.info(f"registering {dev.hostname} to collector")
+            logger.info("registering %s to collector", dev.hostname)
             fritzcollector.register(fritz_device)
 
     REGISTRY.register(fritzcollector)
 
-    logger.info(f"Starting listener at {config.exporter_port}")
+    logger.info("Starting listener at %d", config.exporter_port)
     start_http_server(int(config.exporter_port))
 
     logger.info("Entering async main loop - exporter is ready")

--- a/fritzexporter/action_blacklists.py
+++ b/fritzexporter/action_blacklists.py
@@ -1,0 +1,37 @@
+from typing import NamedTuple
+
+
+class BlacklistItem(NamedTuple):
+    service: str
+    action: str
+    return_value: str | None = None
+
+
+call_blacklist = [
+    BlacklistItem("DeviceConfig1", "GetPersistentData"),
+    BlacklistItem("DeviceConfig1", "X_AVM-DE_GetConfigFile"),
+    BlacklistItem("Hosts1", "X_AVM-DE_GetAutoWakeOnLANByMACAddress"),
+    BlacklistItem("WANCommonInterfaceConfig1", "X_AVM-DE_GetOnlineMonitor"),
+    BlacklistItem("WLANConfiguration1", "GetDefaultWEPKeyIndex"),
+    BlacklistItem("WLANConfiguration2", "GetDefaultWEPKeyIndex"),
+    BlacklistItem("WLANConfiguration3", "GetDefaultWEPKeyIndex"),
+    BlacklistItem("WLANConfiguration4", "GetDefaultWEPKeyIndex"),
+    BlacklistItem("X_AVM-DE_AppSetup1", "GetAppMessageFilter"),
+    BlacklistItem("X_AVM-DE_Filelinks1", "GetNumberOfFilelinkEntries"),
+    BlacklistItem("X_AVM-DE_HostFilter1", "GetTicketIDStatus"),
+    BlacklistItem("X_AVM-DE_OnTel1", "GetCallBarringEntry"),
+    BlacklistItem("X_AVM-DE_OnTel1", "GetCallBarringEntryByNum"),
+    BlacklistItem("X_AVM-DE_OnTel1", "GetDeflection"),
+    BlacklistItem("X_AVM-DE_OnTel1", "GetPhonebook"),
+    BlacklistItem("X_AVM-DE_OnTel1", "GetPhonebookEntry"),
+    BlacklistItem("X_AVM-DE_OnTel1", "GetPhonebookEntryUID"),
+    BlacklistItem("X_AVM-DE_TAM1", "GetInfo"),
+    BlacklistItem("X_VoIP1", "GetVoIPEnableAreaCode"),
+    BlacklistItem("X_VoIP1", "GetVoIPEnableCountryCode"),
+    BlacklistItem("X_VoIP1", "X_AVM-DE_GetClient"),
+    BlacklistItem("X_VoIP1", "X_AVM-DE_GetClient2"),
+    BlacklistItem("X_VoIP1", "X_AVM-DE_GetClient3"),
+    BlacklistItem("X_VoIP1", "X_AVM-DE_GetClientByClientId"),
+    BlacklistItem("X_VoIP1", "X_AVM-DE_GetPhonePort"),
+    BlacklistItem("X_VoIP1", "X_AVM-DE_GetVoIPAccount"),
+]

--- a/fritzexporter/data_donation.py
+++ b/fritzexporter/data_donation.py
@@ -6,7 +6,7 @@ import os
 from typing import Any
 
 import requests
-from fritzconnection.core.exceptions import (
+from fritzconnection.core.exceptions import (  # type: ignore[import]
     FritzActionError,
     FritzArgumentError,
     FritzConnectionException,
@@ -14,7 +14,7 @@ from fritzconnection.core.exceptions import (
 )
 
 from . import __version__
-from .action_blacklists import call_blacklist
+from .action_blacklists import BlacklistItem, call_blacklist
 from .fritzdevice import FritzDevice
 
 logger = logging.getLogger("fritzexporter.donate_data")
@@ -32,7 +32,7 @@ def get_sw_version(device: FritzDevice) -> str:
 
 
 def safe_call_action(device: FritzDevice, service: str, action: str) -> dict[str, str]:
-    if (service, action) in call_blacklist:
+    if BlacklistItem(service, action) in call_blacklist:
         return {"error": "<BLACKLISTED>"}
 
     try:

--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -5,7 +5,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from fritzconnection.core.exceptions import (
+from fritzconnection.core.exceptions import (  # type: ignore[import]
     FritzActionError,
     FritzArgumentError,
     FritzArrayIndexError,

--- a/fritzexporter/fritzdevice.py
+++ b/fritzexporter/fritzdevice.py
@@ -3,8 +3,8 @@ import logging
 import sys
 from typing import NamedTuple
 
-from fritzconnection import FritzConnection
-from fritzconnection.core.exceptions import (
+from fritzconnection import FritzConnection  # type: ignore[import]
+from fritzconnection.core.exceptions import (  # type: ignore[import]
     FritzActionError,
     FritzConnectionException,
     FritzServiceError,
@@ -36,7 +36,8 @@ class FritzDevice:
 
         if len(creds.password) > FRITZ_MAX_PASSWORD_LENGTH:
             logger.warning(
-                "Password is longer than 32 characters! Login may not succeed, please see README!"
+                "Password is longer than %d characters! Login may not succeed, please see README!",
+                FRITZ_MAX_PASSWORD_LENGTH,
             )
 
         try:
@@ -48,7 +49,7 @@ class FritzDevice:
             raise
 
         logger.info("Connection to %s successful, reading capabilities", creds.host)
-        self.capabilities = FritzCapabilities(self, host_info)
+        self.capabilities = FritzCapabilities(self)
 
         self.get_device_info()
         logger.info(
@@ -86,7 +87,7 @@ class FritzDevice:
 class FritzCollector:
     def __init__(self):
         self.devices: list[FritzDevice] = []
-        self.capabilities: FritzCapabilities = FritzCapabilities(host_info=True)
+        self.capabilities: FritzCapabilities = FritzCapabilities()  # host_info=True??? FIXME
 
     def register(self, fritzdev: FritzDevice) -> None:
         self.devices.append(fritzdev)

--- a/fritzexporter/fritzdevice.py
+++ b/fritzexporter/fritzdevice.py
@@ -1,5 +1,7 @@
+import collections
 import logging
 import sys
+from typing import NamedTuple
 
 from fritzconnection import FritzConnection
 from fritzconnection.core.exceptions import (
@@ -7,6 +9,7 @@ from fritzconnection.core.exceptions import (
     FritzConnectionException,
     FritzServiceError,
 )
+from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
 
 from fritzexporter.exceptions import FritzDeviceHasNoCapabilitiesError
 from fritzexporter.fritzcapabilities import FritzCapabilities
@@ -14,57 +17,69 @@ from fritzexporter.fritzcapabilities import FritzCapabilities
 logger = logging.getLogger("fritzexporter.fritzdevice")
 
 
+FRITZ_MAX_PASSWORD_LENGTH = 32
+
+
+class FritzCredentials(NamedTuple):
+    host: str
+    user: str
+    password: str
+
+
 class FritzDevice:
-    def __init__(
-        self, host: str, user: str, password: str, name: str, host_info: bool = False
-    ) -> None:
-        self.host: str = host
+    def __init__(self, creds: FritzCredentials, name: str, *, host_info: bool = False) -> None:
+        self.host: str = creds.host
         self.serial: str = "n/a"
         self.model: str = "n/a"
         self.friendly_name: str = name
         self.host_info: bool = host_info
 
-        if len(password) > 32:
+        if len(creds.password) > FRITZ_MAX_PASSWORD_LENGTH:
             logger.warning(
                 "Password is longer than 32 characters! Login may not succeed, please see README!"
             )
 
         try:
-            self.fc: FritzConnection = FritzConnection(address=host, user=user, password=password)
-        except FritzConnectionException as e:
-            logger.exception(f"unable to connect to {host}: {str(e)}", exc_info=True)
-            raise e
+            self.fc: FritzConnection = FritzConnection(
+                address=creds.host, user=creds.user, password=creds.password
+            )
+        except FritzConnectionException:
+            logger.exception("unable to connect to %s.", creds.host)
+            raise
 
-        logger.info(f"Connection to {host} successful, reading capabilities")
+        logger.info("Connection to %s successful, reading capabilities", creds.host)
         self.capabilities = FritzCapabilities(self, host_info)
 
         self.get_device_info()
         logger.info(
-            f"Reading capabilities for {host}, got serial {self.serial}, "
-            f"model name {self.model} completed"
+            "Reading capabilities for %s, got serial %s, model name %s completed",
+            creds.host,
+            self.serial,
+            self.model,
         )
         if host_info:
             logger.info(
-                f"HostInfo Capability enabled on device {host}. "
+                "HostInfo Capability enabled on device %s. "
                 "This will cause slow responses from the exporter. "
-                "Ensure prometheus is configured appropriately."
+                "Ensure prometheus is configured appropriately.",
+                creds.host,
             )
         if self.capabilities.empty():
-            logger.critical(f"Device {host} has no detected capabilities. Exiting.")
+            logger.critical("Device %s has no detected capabilities. Exiting.", creds.host)
             raise FritzDeviceHasNoCapabilitiesError
 
-    def get_device_info(self):
+    def get_device_info(self) -> None:
         try:
             device_info: dict[str, str] = self.fc.call_action("DeviceInfo1", "GetInfo")
-            self.serial: str = device_info["NewSerialNumber"]
-            self.model: str = device_info["NewModelName"]
+            self.serial = device_info["NewSerialNumber"]
+            self.model = device_info["NewModelName"]
 
         except (FritzServiceError, FritzActionError):
-            logger.error(
-                f"Fritz Device {self.host} does not provide basic device "
+            logger.exception(
+                "Fritz Device %s does not provide basic device "
                 "info (Service: DeviceInfo1, Action: GetInfo)."
                 "Serial number and model name will be unavailable.",
-                exc_info=True,
+                self.host,
             )
 
 
@@ -73,19 +88,19 @@ class FritzCollector:
         self.devices: list[FritzDevice] = []
         self.capabilities: FritzCapabilities = FritzCapabilities(host_info=True)
 
-    def register(self, fritzdev):
+    def register(self, fritzdev: FritzDevice) -> None:
         self.devices.append(fritzdev)
-        logger.debug(f"registered device {fritzdev.host} ({fritzdev.model}) to collector")
+        logger.debug("registered device %s (%s) to collector", fritzdev.host, fritzdev.model)
         self.capabilities.merge(fritzdev.capabilities)
 
-    def collect(self):
+    def collect(self) -> collections.abc.Iterable[CounterMetricFamily | GaugeMetricFamily]:
         if not self.devices:
             logger.critical("No devices registered in collector! Exiting.")
             sys.exit(1)
 
         for name, capa in self.capabilities.items():
-            capa.createMetrics()
-            yield from capa.getMetrics(self.devices, name)
+            capa.create_metrics()
+            yield from capa.get_metrics(self.devices, name)
 
 
 # Copyright 2019-2023 Patrick Dreker <patrick@dreker.de>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,3 @@
-[tool.pytest.ini_options]
-minversion = "6.0"
-addopts = "--cov-branch --cov . --cov-report xml --cov-config .coveragerc"
-testpaths = [
-    "tests",
-]
-
 [tool.poetry]
 name = "fritz-exporter"
 version = "2.3.1"
@@ -27,7 +20,7 @@ include = [ "LICENSE.md" ]
 packages = [{include = "fritzexporter"}]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.11"
 prometheus-client = ">=0.6.0"
 fritzconnection = ">=1.0.0"
 pyyaml = "*"
@@ -43,6 +36,17 @@ mypy = ">=0.971,<1.8"
 coverage = ">=6.4.4,<8.0.0"
 pytest-cov = ">=3,<5"
 ruff = "^0.1.7"
+
+[project]
+name = "fritz-exporter"
+requires-python = ">=3.11,<4.0"
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "--cov-branch --cov . --cov-report xml --cov-config .coveragerc"
+testpaths = [
+    "tests",
+]
 
 [build-system]
 requires = ["poetry-core"]
@@ -110,7 +114,13 @@ select = [
     "RUF", # ruff (various issues)
 ]
 
-ignore = ['E203', 'COM812', 'ISC001']
+ignore = ['E203', 'COM812', 'ISC001', 'ANN101', 'ANN102', 'ANN204']
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[tool.mypy]
+exclude = [
+    '^tests/',
+    '^docs/',
+]

--- a/tests/test_datadonation.py
+++ b/tests/test_datadonation.py
@@ -16,7 +16,7 @@ from fritzexporter.data_donation import (
     safe_call_action,
     sanitize_results,
 )
-from fritzexporter.fritzdevice import FritzDevice
+from fritzexporter.fritzdevice import FritzCredentials, FritzDevice
 
 from .fc_services_mock import (
     call_action_mock,
@@ -52,7 +52,7 @@ class TestDataDonation:
         fc.services = create_fc_services(fc_services_capabilities["DeviceInfo"])
 
         # Act
-        fd = FritzDevice("somehost", "someuser", "password", "FritzMock", False)
+        fd = FritzDevice(FritzCredentials("somehost", "someuser", "password"), "FritzMock", host_info=False)
         version = get_sw_version(fd)
 
         # Check
@@ -67,7 +67,7 @@ class TestDataDonation:
         fc.services = create_fc_services(fc_services_no_basic_info)
 
         # Act
-        fd = FritzDevice("somehost", "someuser", "password", "FritzMock", False)
+        fd = FritzDevice(FritzCredentials("somehost", "someuser", "password"), "FritzMock", host_info=False)
         version = get_sw_version(fd)
 
         # Check
@@ -82,7 +82,7 @@ class TestDataDonation:
         fc.services = create_fc_services(fc_services_no_basic_info)
 
         # Act
-        fd = FritzDevice("somehost", "someuser", "password", "FritzMock", False)
+        fd = FritzDevice(FritzCredentials("somehost", "someuser", "password"), "FritzMock", host_info=False)
         version = get_sw_version(fd)
 
         # Check
@@ -101,7 +101,7 @@ class TestDataDonation:
         fc.services = create_fc_services(fc_services_no_basic_info)
 
         # Act
-        fd = FritzDevice("somehost", "someuser", "password", "FritzMock", False)
+        fd = FritzDevice(FritzCredentials("somehost", "someuser", "password"), "FritzMock", host_info=False)
         fc.call_action.side_effect = exception
         res = safe_call_action(fd, "foo", "bar")
 
@@ -117,7 +117,7 @@ class TestDataDonation:
         fc.services = create_fc_services(fc_services_devices["FritzBox 7590"])
 
         # Act
-        fd = FritzDevice("somehost", "someuser", "password", "FritzMock", False)
+        fd = FritzDevice(FritzCredentials("somehost", "someuser", "password"), "FritzMock", host_info=False)
         res = safe_call_action(fd, "DeviceConfig1", "GetPersistentData")
 
         # Check
@@ -221,7 +221,7 @@ class TestDataDonation:
         fc.services = create_fc_services(fc_services_capabilities["HostNumberOfEntries"])
 
         # Act
-        fd = FritzDevice("somehost", "someuser", "password", "FritzMock", False)
+        fd = FritzDevice(FritzCredentials("somehost", "someuser", "password"), "FritzMock", host_info=False)
         donate_data(fd, upload=True)
 
         # check
@@ -237,7 +237,7 @@ class TestDataDonation:
             '"WanCommonInterfaceDataPackets", "WlanConfigurationInfo", "HostInfo", '
             '"HomeAutomation"], "action_results": {"Hosts1": {"GetHostNumberOfEntries": '
             '{"NewHostNumberOfEntries": "3"}}}}}',
-            headers={"Content-Type": "application/json"},
+            headers={"Content-Type": "application/json"},timeout=10,
         )
 
     @patch("fritzexporter.data_donation.requests.post")
@@ -252,7 +252,7 @@ class TestDataDonation:
         fc.services = create_fc_services(fc_services_capabilities["HostNumberOfEntries"])
 
         # Act
-        fd = FritzDevice("somehost", "someuser", "password", "FritzMock", False)
+        fd = FritzDevice(FritzCredentials("somehost", "someuser", "password"), "FritzMock", host_info=False)
         donate_data(fd)
 
         # check
@@ -276,7 +276,7 @@ class TestDataDonation:
         fc.services = create_fc_services(fc_services_capabilities["HostNumberOfEntries"])
 
         # Act 1
-        fd = FritzDevice("somehost", "someuser", "password", "FritzMock", False)
+        fd = FritzDevice(FritzCredentials("somehost", "someuser", "password"), "FritzMock", host_info=False)
         donate_data(fd, upload=True)
 
         # Check 1

--- a/tests/test_fritzdevice.py
+++ b/tests/test_fritzdevice.py
@@ -7,7 +7,7 @@ from fritzconnection.core.exceptions import FritzConnectionException, FritzServi
 from prometheus_client.core import Metric
 
 from fritzexporter.exceptions import FritzDeviceHasNoCapabilitiesError
-from fritzexporter.fritzdevice import FritzCollector, FritzDevice
+from fritzexporter.fritzdevice import FritzCollector, FritzCredentials, FritzDevice
 
 from .fc_services_mock import (
     call_action_mock,
@@ -36,9 +36,9 @@ class TestFritzDevice:
 
         # Act
         if capability == "HostInfo":
-            fd = FritzDevice("somehost", "someuser", "password", "FritzMock", True)
+            fd = FritzDevice(FritzCredentials("somehost", "someuser", "password"), "FritzMock", host_info=True)
         else:
-            fd = FritzDevice("somehost", "someuser", "password", "FritzMock", False)
+            fd = FritzDevice(FritzCredentials("somehost", "someuser", "password"), "FritzMock", host_info=False)
 
         # Check
         print(caplog.text)
@@ -81,13 +81,13 @@ class TestFritzDevice:
 
         # Act
         with pytest.raises(FritzConnectionException):
-            _ = FritzDevice("somehost", "someuser", "password", "FritzMock", False)
+            _ = FritzDevice(FritzCredentials("somehost", "someuser", "password"), "FritzMock", host_info=False)
 
         # Check
         assert (
             FRITZDEVICE_LOG_SOURCE,
             logging.ERROR,
-            "unable to connect to somehost: somehost: connection refused",
+            "unable to connect to somehost.",
         ) in caplog.record_tuples
 
     def test_should_invalidate_presented_service(self, mock_fritzconnection: MagicMock, caplog):
@@ -100,7 +100,7 @@ class TestFritzDevice:
 
         # Act
         with pytest.raises(FritzDeviceHasNoCapabilitiesError):
-            _ = FritzDevice("somehost", "someuser", "password", "FritzMock", True)
+            _ = FritzDevice(FritzCredentials("somehost", "someuser", "password"), "FritzMock", host_info=True)
 
     def test_should_create_fritz_device_with_correct_capabilities(
         self, mock_fritzconnection: MagicMock, caplog
@@ -113,7 +113,7 @@ class TestFritzDevice:
         fc.services = create_fc_services(fc_services_devices["FritzBox 7590"])
 
         # Act
-        fd = FritzDevice("somehost", "someuser", "password", "FritzMock", False)
+        fd = FritzDevice(FritzCredentials("somehost", "someuser", "password"), "FritzMock", host_info=False)
 
         # Check
         assert fd.model == "Fritz!MockBox 9790"
@@ -134,7 +134,7 @@ class TestFritzDevice:
         fc.services = create_fc_services(fc_services_devices["FritzBox 7590"])
 
         # Act
-        _ = FritzDevice("somehost", "someuser", password, "Fritz!Mock", False)
+        _ = FritzDevice(FritzCredentials("somehost", "someuser", password), "Fritz!Mock", host_info=False)
 
         # Check
         assert (
@@ -154,7 +154,7 @@ class TestFritzDevice:
 
         # Act
         with pytest.raises(FritzDeviceHasNoCapabilitiesError):
-            _ = FritzDevice("somehost", "someuser", password, "FritzMock", False)
+            _ = FritzDevice(FritzCredentials("somehost", "someuser", password), "FritzMock", host_info=False)
 
         # Check
         assert (
@@ -172,7 +172,7 @@ class TestFritzDevice:
         fc.services = create_fc_services(fc_services_no_basic_info)
 
         # Act
-        _ = FritzDevice("somehost", "someuser", "password", "FritzMock", False)
+        _ = FritzDevice(FritzCredentials("somehost", "someuser", "password"), "FritzMock", host_info=False)
 
         # Check
         assert (
@@ -226,7 +226,7 @@ class TestFritzCollector:
 
         # Act
         collector = FritzCollector()
-        device = FritzDevice("somehost", "someuser", "password", "FritzMock", False)
+        device = FritzDevice(FritzCredentials("somehost", "someuser", "password"), "FritzMock", host_info=False)
         collector.register(device)
 
         # Check
@@ -243,7 +243,7 @@ class TestFritzCollector:
 
         # Act
         collector = FritzCollector()
-        device = FritzDevice("somehost", "someuser", "password", "FritzMock", False)
+        device = FritzDevice(FritzCredentials("somehost", "someuser", "password"), "FritzMock", host_info=False)
         collector.register(device)
         metrics: list[Metric] = list(collector.collect())
 
@@ -267,7 +267,7 @@ class TestFritzCollector:
 
         # Act
         collector = FritzCollector()
-        device = FritzDevice("somehost", "someuser", "password", "FritzMock", True)
+        device = FritzDevice(FritzCredentials("somehost", "someuser", "password"), "FritzMock", host_info=True)
         collector.register(device)
         metrics: list[Metric] = list(collector.collect())
 
@@ -292,9 +292,9 @@ class TestFritzCollector:
 
         # Act
         collector = FritzCollector()
-        device1 = FritzDevice("somehost", "someuser", "password", "FritzMock1", True)
-        device2 = FritzDevice("somehost", "someuser", "password", "FritzMock2", True)
-        device3 = FritzDevice("somehost", "someuser", "password", "FritzMock3", True)
+        device1 = FritzDevice(FritzCredentials("somehost", "someuser", "password"), "FritzMock1", host_info=True)
+        device2 = FritzDevice(FritzCredentials("somehost", "someuser", "password"), "FritzMock2", host_info=True)
+        device3 = FritzDevice(FritzCredentials("somehost", "someuser", "password"), "FritzMock3", host_info=True)
         collector.register(device1)
         collector.register(device2)
         collector.register(device3)


### PR DESCRIPTION
Try using "ruff" for linting/formatting. Uses a lot more rules, whioch in turn requires some refactoring - non functional changes.

Actually this uncovered that FritzCapabilities was using a parameter it never needed. :-)