### PR TITLE
feat: add Homeautomation metrics via HTTP

### DIFF
--- a/fritzexporter/data_donation.py
+++ b/fritzexporter/data_donation.py
@@ -249,8 +249,6 @@ def donate_data(
                 res = safe_call_action(device, service, action)
                 action_results[(service, action)] = res
 
-    action_results = jsonify_action_results(sanitize_results(action_results, sanitation))
-
     basedata = {
         "exporter_version": __version__,
         "fritzdevice": {
@@ -258,7 +256,7 @@ def donate_data(
             "os_version": sw_version,
             "services": services,
             "detected_capabilities": detected_capabilities,
-            "action_results": action_results,
+            "action_results": jsonify_action_results(sanitize_results(action_results, sanitation)),
         },
     }
 

--- a/fritzexporter/fritz_aha.py
+++ b/fritzexporter/fritz_aha.py
@@ -4,13 +4,15 @@ from defusedxml import ElementTree
 def parse_aha_device_xml(deviceinfo: str) -> dict[str, str]:
     device: ElementTree = ElementTree.fromstring(deviceinfo)
 
-    battery_level = device.find("battery").text
-    battery_low = device.find("batterylow").text
+    battery_level = device.find("battery")
+    battery_low = device.find("batterylow")
 
     result = {}
-    if battery_level:
-        result["battery_level"] = battery_level
-    if battery_low:
-        result["battery_low"] = battery_low
+
+    if battery_level is not None:
+        result["battery_level"] = battery_level.text
+
+    if battery_low is not None:
+        result["battery_low"] = battery_low.text
 
     return result

--- a/fritzexporter/fritz_aha.py
+++ b/fritzexporter/fritz_aha.py
@@ -1,0 +1,16 @@
+from defusedxml import ElementTree
+
+
+def parse_aha_device_xml(deviceinfo: str) -> dict[str, str]:
+    device: ElementTree = ElementTree.fromstring(deviceinfo)
+
+    battery_level = device.find("battery").text
+    battery_low = device.find("batterylow").text
+
+    result = {}
+    if battery_level:
+        result["battery_level"] = battery_level
+    if battery_low:
+        result["battery_low"] = battery_low
+
+    return result

--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -1421,7 +1421,7 @@ class HomeAutomation(FritzCapability):
                             manufacturer,
                             productname,
                         ],
-                        http_data["battery"],
+                        float(http_data["battery"]),
                     )
 
                 if "battery_low" in http_data:
@@ -1434,7 +1434,7 @@ class HomeAutomation(FritzCapability):
                             manufacturer,
                             productname,
                         ],
-                        1 if http_data["battery_low"] else 0,
+                        1 if http_data["battery_low"] == "1" else 0,
                     )
 
     def _get_metric_values(

--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -9,10 +9,13 @@ from fritzconnection.core.exceptions import (  # type: ignore[import]
     FritzActionError,
     FritzArgumentError,
     FritzArrayIndexError,
+    FritzHttpInterfaceError,
     FritzInternalError,
     FritzServiceError,
 )
 from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
+
+from fritzexporter.fritz_aha import parse_aha_device_xml
 
 if TYPE_CHECKING:
     from fritzexporter.fritzdevice import FritzDevice
@@ -979,6 +982,35 @@ class HomeAutomation(FritzCapability):
                 "productname",
             ],
         )
+
+        self.metrics["battery_level"] = GaugeMetricFamily(
+            "fritz_ha_battery_level",
+            "Battery level in percent",
+            labels=[
+                "serial",
+                "friendly_name",
+                "ain",
+                "device_name",
+                "device_id",
+                "manufacturer",
+                "productname",
+            ],
+        )
+
+        self.metrics["battery_low"] = GaugeMetricFamily(
+            "fritz_ha_battery_low",
+            "Indicates that the battery is low",
+            labels=[
+                "serial",
+                "friendly_name",
+                "ain",
+                "device_name",
+                "device_id",
+                "manufacturer",
+                "productname",
+            ],
+        )
+
         self.metrics["multimeter_power"] = GaugeMetricFamily(
             "fritz_ha_multimeter_power_W",
             "Power in W",
@@ -1370,6 +1402,40 @@ class HomeAutomation(FritzCapability):
                 )
 
             index += 1
+
+            try:
+                http_result = device.fc.call_http("getdeviceinfos", ain)
+            except FritzHttpInterfaceError:
+                logger.debug("Got FritzHttpInterfaceError for ain %s, skipping", ain)
+                continue
+
+            if "content" in http_result:
+                http_data = parse_aha_device_xml(http_result["content"])
+                if "battery" in http_data:
+                    self.metrics["battery_level"].add_metric(
+                        [
+                            device.serial,
+                            device.friendly_name,
+                            ain,
+                            device_name,
+                            manufacturer,
+                            productname,
+                        ],
+                        http_data["battery"],
+                    )
+
+                if "battery_low" in http_data:
+                    self.metrics["battery_low"].add_metric(
+                        [
+                            device.serial,
+                            device.friendly_name,
+                            ain,
+                            device_name,
+                            manufacturer,
+                            productname,
+                        ],
+                        1 if http_data["battery_low"] else 0,
+                    )
 
     def _get_metric_values(
         self,

--- a/fritzexporter/fritzdevice.py
+++ b/fritzexporter/fritzdevice.py
@@ -10,6 +10,7 @@ from fritzconnection.core.exceptions import (  # type: ignore[import]
     FritzServiceError,
 )
 from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
+from prometheus_client.registry import Collector
 
 from fritzexporter.exceptions import FritzDeviceHasNoCapabilitiesError
 from fritzexporter.fritzcapabilities import FritzCapabilities
@@ -84,7 +85,7 @@ class FritzDevice:
             )
 
 
-class FritzCollector:
+class FritzCollector(Collector):
     def __init__(self):
         self.devices: list[FritzDevice] = []
         self.capabilities: FritzCapabilities = FritzCapabilities()  # host_info=True??? FIXME

--- a/poetry.lock
+++ b/poetry.lock
@@ -204,6 +204,17 @@ files = [
 toml = ["tomli"]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+description = "XML bomb protection for Python stdlib modules"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+files = [
+    {file = "defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"},
+    {file = "defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"},
+]
+
+[[package]]
 name = "fritzconnection"
 version = "1.13.2"
 description = "Communicate with the AVM FRITZ!Box"
@@ -555,4 +566,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "724d558a131430a6c3cb660215287fd3fae0d4b04cf1a093d9881e06431541bc"
+content-hash = "f578d43740a6335d88914489d663525d9721a0ad5405b56ca1b6e2e09274623a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ fritzconnection = ">=1.0.0"
 pyyaml = "*"
 requests = "*"
 attrs = ">=22.2,<24.0"
+defusedxml = "^0.7.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "*"

--- a/tests/fc_services_mock.py
+++ b/tests/fc_services_mock.py
@@ -18,6 +18,21 @@ def create_fc_services(services_mock):
         services[svc] = FCService(actions)
     return services
 
+def call_http_mock(action, ain, **_):
+    return {
+        "content": """<?xml version="1.0" encoding="utf-8"?>
+        <device>
+            <present>1</present>
+            <name>Fritz!DECT 200</name>
+            <manufacturer>AVM</manufacturer>
+            <manufacturerURL>http://www.avm.de</manufacturerURL>
+            <model>Fritz!DECT 200</model>
+            <battery>100</battery>
+            <batterylow>0</batterylow>
+        </device>""",
+        "content-type": "text/xml",
+        "encoding": "utf-8"
+    }
 
 def call_action_mock(service, action, **kwargs):
     _ = kwargs
@@ -179,8 +194,7 @@ def call_action_mock(service, action, **kwargs):
     return call_action_responses[(service, action)]
 
 
-def call_action_no_basic_mock(service, action, **kwargs):
-    _ = kwargs
+def call_action_no_basic_mock(service, action, **_):
 
     if service == "DeviceInfo1" and action == "GetInfo":
         raise FritzServiceError

--- a/tests/test_fritzdevice.py
+++ b/tests/test_fritzdevice.py
@@ -13,6 +13,7 @@ from fritzexporter.fritz_aha import parse_aha_device_xml
 from .fc_services_mock import (
     call_action_mock,
     call_action_no_basic_mock,
+    call_http_mock,
     create_fc_services,
     fc_services_capabilities,
     fc_services_devices,
@@ -275,6 +276,7 @@ class TestFritzCollector:
 
         fc = mock_fritzconnection.return_value
         fc.call_action.side_effect = call_action_mock
+        fc.call_http.side_effect = call_http_mock
         fc.services = create_fc_services(fc_services_devices["FritzBox 7590"])
 
         # Act

--- a/tests/test_fritzdevice.py
+++ b/tests/test_fritzdevice.py
@@ -8,6 +8,7 @@ from prometheus_client.core import Metric
 
 from fritzexporter.exceptions import FritzDeviceHasNoCapabilitiesError
 from fritzexporter.fritzdevice import FritzCollector, FritzCredentials, FritzDevice
+from fritzexporter.fritz_aha import parse_aha_device_xml
 
 from .fc_services_mock import (
     call_action_mock,
@@ -182,6 +183,28 @@ class TestFritzDevice:
             "info (Service: DeviceInfo1, Action: GetInfo)."
             "Serial number and model name will be unavailable.",
         ) in caplog.record_tuples
+
+    def test_should_correctly_parse_aha_xml(self, mock_fritzconnection: MagicMock, caplog):
+        # Prepare
+        deviceinfo = """<?xml version="1.0" encoding="utf-8"?>
+        <device>
+            <present>1</present>
+            <name>Fritz!DECT 200
+            </name>
+            <manufacturer>AVM</manufacturer>
+            <manufacturerURL>http://www.avm.de</manufacturerURL>
+            <model>Fritz!DECT 200</model>
+            <battery>100</battery>
+            <batterylow>0</batterylow>
+        </device>
+        """
+        # Act
+        device_data = parse_aha_device_xml(deviceinfo)
+
+        # Check
+        assert device_data["battery_level"] == "100"
+        assert device_data["battery_low"] == "0"
+
 
 
 @patch("fritzexporter.fritzdevice.FritzConnection")

--- a/tests/test_fritzdevice.py
+++ b/tests/test_fritzdevice.py
@@ -205,6 +205,19 @@ class TestFritzDevice:
         assert device_data["battery_level"] == "100"
         assert device_data["battery_low"] == "0"
 
+    def test_should_correctly_parse_aha_xml_when_empty(self, mock_fritzconnection: MagicMock, caplog):
+        # Prepare
+        deviceinfo = """<?xml version="1.0" encoding="utf-8"?>
+        <device>
+        </device>
+        """
+        # Act
+        device_data = parse_aha_device_xml(deviceinfo)
+
+        # Check
+        assert "battery_level" not in device_data
+        assert "battery_low" not in device_data
+
 
 
 @patch("fritzexporter.fritzdevice.FritzConnection")


### PR DESCRIPTION
This will start reading various Homeautomation metrics via the AHA homeautomation HTTP API from the FritzBox. Currently this only reads BatteryState (Level in %) and BatteryLow (1 = change battery, 0 = OK)