### PR TITLE
Add handling for xml error when no battery stats are reported by the device

### DIFF
--- a/fritzexporter/fritz_aha.py
+++ b/fritzexporter/fritz_aha.py
@@ -2,17 +2,21 @@ from defusedxml import ElementTree
 
 
 def parse_aha_device_xml(deviceinfo: str) -> dict[str, str]:
-    device: ElementTree = ElementTree.fromstring(deviceinfo)
+    try:
+        device: ElementTree = ElementTree.fromstring(deviceinfo)
 
-    battery_level = device.find("battery")
-    battery_low = device.find("batterylow")
+        battery_level = device.find("battery")
+        battery_low = device.find("batterylow")
 
-    result = {}
+        result = {}
 
-    if battery_level is not None:
-        result["battery_level"] = battery_level.text
+        if battery_level is not None:
+            result["battery_level"] = battery_level.text
 
-    if battery_low is not None:
-        result["battery_low"] = battery_low.text
+        if battery_low is not None:
+            result["battery_low"] = battery_low.text
 
-    return result
+        return result
+
+    except ElementTree.ParseError as e:
+        return {}


### PR DESCRIPTION
As previously mentioned here: 

https://github.com/pdreker/fritz_exporter/issues/245#issuecomment-1875912021

My watchtower instance automatically updated my container to the 2.4 release and it started crashing immediately. You mentioned in your comment [here](https://github.com/pdreker/fritz_exporter/issues/245#issuecomment-1890384275) that you would consider just handling the parse error. This is what this patch should do.

Unfortunately, I'm not really able to test because I just can't get poetry installed on my system and I'm still struggling to get a newer python to work since the 3.6 release I have currently won't let me run the code directly.