### PR TITLE
chore: bump Helm chart to 0.2.0, app version to 2.5.0

### DIFF
--- a/helm/fritz-exporter/Chart.yaml
+++ b/helm/fritz-exporter/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: fritz-exporter
 description: fritz-exporter Helm Chart
 type: application
-version: 0.1.0
-appVersion: "2.2.0"
+version: 0.2.0
+appVersion: "2.5.0"
 maintainers:
   - email: patrick@dreker.de
     name: Patrick Dreker


### PR DESCRIPTION
Hey @pdreker, thank you for `fritz_exporter`! Really great project.

I came across it and used the Helm chart to deploy it, works like a charm. Only modification I had to make was to bump the appVersion to 2.5.0 so it would use the latest version of the exporter (2.2.0 is pretty old at this point, after all).

Helm charts also need a version bump usually, so I took the freedom to bump it from 0.1.0 to 0.2.0 since it has been sitting at that version for a bit too long maybe.

Hope this PR is helpful you, I saw that the Helm chart was considered "a hot mess" at some point, but it seems to be quite solid. If this isn't desired, feel free to close the PR!