### PR TITLE
fix(docs): minimize Fritz!Box user permissions

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -12,7 +12,7 @@ This Quickstart is intended for users, who have no current Prometheus or Grafana
 Preparations
 ------------
 
-Create a new user account for the exporter on the Fritzbox using the login credentials FRITZ_USERNAME: 'xxxxx' and FRITZ_PASSWORD: 'xxxx'. Grant the user access to the following features: FRITZ!Box settings, voice messages, fax messages, FRITZ!App Fon and call list, Smart Home, access to NAS content, and VPN.
+Create a new user account for the exporter on the Fritzbox using the login credentials FRITZ_USERNAME: 'xxxxx' and FRITZ_PASSWORD: 'xxxx'. Grant the user access to the FRITZ!Box settings. This automaticaly also allows voice messages, fax messages, FRITZ!App Fon and call list, and Smart Home.
 
 Create an empty directory ``fritz-exporter`` and place a file ``docker-compose.yml`` in that directory with the following content (Check that environment variables and paths match your setup):
 


### PR DESCRIPTION
Allowing to manage VPN connections would allow to expose the Fritz!Box to remote access and is a pretty privileged permission in the Fritz!Box. You even need to approve it by pressing a physical button or second factor.

For example the [Home Assistant integration is only requiring access to the settings](https://www.home-assistant.io/integrations/fritz/#username) and it's using the [same library](https://github.com/home-assistant/core/blob/dev/homeassistant/components/fritz/manifest.json) internally.

So I tried it out and with only permissions for settings and the automatic permissions for phone and smart home stuff, it still works as before.