### PR TITLE
build(helm): bump chart version for 2.7.0 release

### DIFF
--- a/helm/fritz-exporter/Chart.yaml
+++ b/helm/fritz-exporter/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: fritz-exporter
 description: fritz-exporter Helm Chart
 type: application
-version: 0.3.0
-appVersion: "2.6.1"
+version: 0.3.1
+appVersion: "2.7.0"
 maintainers:
   - email: patrick@dreker.de
     name: Patrick Dreker


### PR DESCRIPTION
bump Helm chart appVersion to 2.7.0
bump Helm chart version to 0.3.1
This follows up on the release PR so chart users also get an updated chart release.