### PR TITLE
fix: resolve type errors surfaced by ty migration

### DIFF
--- a/fritzexporter/__init__.py
+++ b/fritzexporter/__init__.py
@@ -1,7 +1,7 @@
 from importlib import metadata
 
 try:
-    __version__ = metadata.version(__package__)
+    __version__ = metadata.version(__package__ or "")
 except metadata.PackageNotFoundError:
     __version__ = "develop"
 finally:

--- a/fritzexporter/config/config.py
+++ b/fritzexporter/config/config.py
@@ -112,7 +112,7 @@ class ExporterConfig:
     # https://github.com/pdreker/fritz_exporter/issues/402
     listen_address: str = field(default="0.0.0.0")  # noqa: S104
 
-    @devices.validator
+    @devices.validator  # ty: ignore[unresolved-attribute]
     def check_devices(self, _: attrs.Attribute, value: list[DeviceConfig]) -> None:
         if value in [None, []]:
             logger.exception("No devices found in config.")
@@ -122,7 +122,7 @@ class ExporterConfig:
         if len(devicenames) != len(set(devicenames)):
             logger.warning("Device names are not unique")
 
-    @listen_address.validator
+    @listen_address.validator  # ty: ignore[unresolved-attribute]
     def check_listen_address(self, _: attrs.Attribute, value: str) -> None:
         _: ipaddress.IPv4Address | ipaddress.IPv6Address = ipaddress.ip_address(value)
 
@@ -166,7 +166,7 @@ class DeviceConfig:
     name: str = ""
     host_info: bool = field(default=False, converter=converters.to_bool)
 
-    @password.validator
+    @password.validator  # ty: ignore[unresolved-attribute]
     def check_password(self, _: attrs.Attribute, value: str | None) -> None:
         if value is not None and len(value) > FRITZ_MAX_PASSWORD_LENGTH:
             logger.exception(
@@ -175,7 +175,7 @@ class DeviceConfig:
             )
             raise FritzPasswordTooLongError
 
-    @password_file.validator
+    @password_file.validator  # ty: ignore[unresolved-attribute]
     def check_password_file(self, _: attrs.Attribute, value: str | None) -> None:
         if value is not None and not Path(value).is_file():
             logger.exception("Password file does not exist!")

--- a/fritzexporter/fritz_aha.py
+++ b/fritzexporter/fritz_aha.py
@@ -1,9 +1,11 @@
+from xml.etree.ElementTree import Element
+
 from defusedxml import ElementTree
 
 
 def parse_aha_device_xml(deviceinfo: str) -> dict[str, str]:
     try:
-        device: ElementTree = ElementTree.fromstring(deviceinfo)
+        device: Element = ElementTree.fromstring(deviceinfo)
 
         battery_level = device.find("battery")
         battery_low = device.find("batterylow")
@@ -11,10 +13,10 @@ def parse_aha_device_xml(deviceinfo: str) -> dict[str, str]:
         result = {}
 
         if battery_level is not None:
-            result["battery_level"] = battery_level.text
+            result["battery_level"] = battery_level.text or ""
 
         if battery_low is not None:
-            result["battery_low"] = battery_low.text
+            result["battery_low"] = battery_low.text or ""
 
     except ElementTree.ParseError:
         return {}

--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -4,7 +4,7 @@ import collections
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Generator, Iterator
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from fritzconnection.core.exceptions import (  # type: ignore[import]
     FritzActionError,
@@ -738,7 +738,7 @@ class WlanConfigurationInfo(FritzCapability):
             device.host,
             self.__class__.__name__,
         )
-        for index, wlan in enumerate(device.capabilities[self.__class__.__name__].wifi_present):
+        for index, wlan in enumerate(cast(WlanConfigurationInfo, device.capabilities[self.__class__.__name__]).wifi_present):
             logger.debug(
                 "WLANConfigurationInfo._generateMetricValues checking WLAN %s (enabled: %s) on %s",
                 index,


### PR DESCRIPTION
## What changed

Fixes the 7 diagnostics reported by `ty check` after migrating from mypy to ty.

| File | Error | Fix |
|---|---|---|
| `__init__.py` | `__package__` is `str \| None`, but `metadata.version()` requires `str` | `__package__ or ""` |
| `fritz_aha.py` | `ElementTree` module used as a type annotation | Changed to `xml.etree.ElementTree.Element` |
| `fritz_aha.py` | `element.text` is `str \| None`, return type is `dict[str, str]` | Guard with `or ""` |
| `config.py` (×4) | ty doesn't model the attrs field `.validator` descriptor | `# ty: ignore[unresolved-attribute]` |
| `fritzcapabilities.py` | `capabilities[name]` returns `FritzCapability` base type, which lacks `wifi_present` | `cast(WlanConfigurationInfo, ...)` |

## Notes for reviewer

- The `# ty: ignore` suppressions on the attrs validators are a limitation of ty's stubs for attrs — the `.validator` decorator pattern is valid at runtime but not reflected in the type stubs. No behavioural change.
- The `or ""` fallback in `fritz_aha.py` matches what was already implicitly assumed; an XML element with no text content would have returned `None` into a `dict[str, str]` previously.

`ty check` now exits clean.