### PR TITLE
docs: add CLAUDE.md and update AGENTS.md with branching rules and uv migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ class DeviceConfig:
 
 **ruff** is the linter. Run it with:
 ```bash
-poetry run ruff check fritzexporter/
+uv run ruff check fritzexporter/
 ```
 
 Key configuration (see `pyproject.toml` `[tool.ruff]`):
@@ -83,7 +83,7 @@ Key configuration (see `pyproject.toml` `[tool.ruff]`):
 
 Tests use **pytest**. Run with:
 ```bash
-poetry run pytest
+uv run pytest
 ```
 
 - Test files are in the `tests/` directory.
@@ -166,10 +166,21 @@ fritzexporter/
 
 ## Dependency Management
 
-- Dependencies are managed with **Poetry** (`pyproject.toml`, `poetry.lock`).
-- Install all dependencies: `poetry install`
-- Add a dependency: `poetry add <package>`
-- Do not update `poetry.lock` manually.
+- Dependencies are managed with **uv** (`pyproject.toml`, `uv.lock`).
+- Install all dependencies: `uv sync`
+- Add a dependency: `uv add <package>`
+- Remove a dependency: `uv remove <package>`
+- Do not update `uv.lock` manually.
+
+---
+
+## Branching and Pull Requests
+
+- **`main` is a protected branch. Never commit directly to `main`.**
+- All changes must go through a feature branch and a pull request, regardless of how small.
+- Branch naming convention: `<type>/<short-description>` (e.g. `fix/logging-cleanup`, `feat/new-capability`, `docs/update-readme`).
+- Use conventional commit messages (see below) on every commit.
+- Run `uv run pytest` and `uv run ruff check fritzexporter/` before pushing — CI will reject failures.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Code instructions for fritz_exporter
+
+Read [AGENTS.md](AGENTS.md) — it contains all project conventions, architecture, tooling, and branching rules.


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` as a minimal pointer to `AGENTS.md` for Claude Code
- Add explicit branch protection rule to `AGENTS.md`: no direct commits to `main`, all changes via feature branch + PR
- Update dependency management section to reflect the uv migration from #604 (was still referencing poetry)
- Update `poetry run` command examples to `uv run` throughout

## Test plan

- [ ] No code changes — docs only
- [ ] Verify `AGENTS.md` renders correctly on GitHub
- [ ] Verify `CLAUDE.md` is picked up by Claude Code in future sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)