### PR TITLE
fix: code review phase 1 — logging, data_donation, HostInfo, asyncio

### DIFF
--- a/fritzexporter/__main__.py
+++ b/fritzexporter/__main__.py
@@ -1,8 +1,8 @@
 import argparse
-import asyncio
 import logging
 import os
 import sys
+import threading
 from pathlib import Path
 
 from fritzconnection.core.exceptions import (  # type: ignore[import]
@@ -138,15 +138,11 @@ def main() -> None:
     logger.info("Starting listener at %s:%d", config.listen_address, config.exporter_port)
     start_http_server(int(config.exporter_port), str(config.listen_address))
 
-    logger.info("Entering async main loop - exporter is ready")
-    loop = asyncio.new_event_loop()
+    logger.info("Exporter is ready")
 
-    # Avoid infinite loop if running tests
+    # Avoid blocking forever when running tests
     if not os.getenv("FRITZ_EXPORTER_UNDER_TEST"):
-        try:
-            loop.run_forever()
-        finally:
-            loop.close()
+        threading.Event().wait()
 
 
 if __name__ == "__main__":

--- a/fritzexporter/config/config.py
+++ b/fritzexporter/config/config.py
@@ -41,14 +41,8 @@ def _read_config_from_env() -> dict:
     if "FRITZ_USERNAME" not in os.environ or all(
         required not in os.environ for required in ["FRITZ_PASSWORD", "FRITZ_PASSWORD_FILE"]
     ):
-        logger.critical(
-            "Required env variables missing "
-            "(FRITZ_USERNAME, FRITZ_PASSWORD or FRITZ_PASSWORD_FILE)!"
-        )
-        msg = (
-            "Required env variables missing "
-            "(FRITZ_USERNAME, FRITZ_PASSWORD or FRITZ_PASSWORD_FILE)!"
-        )
+        msg = "Required env variables missing (FRITZ_USERNAME, FRITZ_PASSWORD or FRITZ_PASSWORD_FILE)!"
+        logger.critical(msg)
         raise ConfigError(msg)
 
     listen_address = os.getenv("FRITZ_LISTEN_ADDRESS")
@@ -115,8 +109,8 @@ class ExporterConfig:
     @devices.validator  # ty: ignore[unresolved-attribute]
     def check_devices(self, _: attrs.Attribute, value: list[DeviceConfig]) -> None:
         if value in [None, []]:
-            logger.exception("No devices found in config.")
             msg = "No devices found in config."
+            logger.error(msg)
             raise NoDevicesFoundError(msg)
         devicenames = [dev.name for dev in value]
         if len(devicenames) != len(set(devicenames)):
@@ -124,13 +118,13 @@ class ExporterConfig:
 
     @listen_address.validator  # ty: ignore[unresolved-attribute]
     def check_listen_address(self, _: attrs.Attribute, value: str) -> None:
-        _: ipaddress.IPv4Address | ipaddress.IPv6Address = ipaddress.ip_address(value)
+        ipaddress.ip_address(value)
 
     @classmethod
     def from_config(cls, config: dict) -> ExporterConfig:
         if config is None:
-            logger.exception("No config found (check Env vars or config file).")
             msg = "No config found (check Env vars or config file)."
+            logger.error(msg)
             raise EmptyConfigError(msg)
 
         exporter_port = config.get("exporter_port", 9787)
@@ -169,7 +163,7 @@ class DeviceConfig:
     @password.validator  # ty: ignore[unresolved-attribute]
     def check_password(self, _: attrs.Attribute, value: str | None) -> None:
         if value is not None and len(value) > FRITZ_MAX_PASSWORD_LENGTH:
-            logger.exception(
+            logger.error(
                 "Password is longer than 32 characters! "
                 "Login may not succeed, please see documentation!"
             )
@@ -178,7 +172,7 @@ class DeviceConfig:
     @password_file.validator  # ty: ignore[unresolved-attribute]
     def check_password_file(self, _: attrs.Attribute, value: str | None) -> None:
         if value is not None and not Path(value).is_file():
-            logger.exception("Password file does not exist!")
+            logger.error("Password file does not exist!")
             raise FritzPasswordFileDoesNotExistError
 
     @classmethod

--- a/fritzexporter/data_donation.py
+++ b/fritzexporter/data_donation.py
@@ -95,66 +95,18 @@ def sanitize_results(
         ],
         ("WANPPPConnection1", "GetUserName"): ["NewUserName"],
         ("WANPPPConnection1", "X_GetDNSServers"): ["NewDNSServers"],
-        ("WLANConfiguration1", "GetBSSID"): ["NewBSSID"],
-        ("WLANConfiguration1", "GetInfo"): ["NewBSSID", "NewSSID"],
-        ("WLANConfiguration1", "GetSSID"): ["NewSSID"],
-        ("WLANConfiguration1", "GetSecurityKeys"): [
-            "NewKeyPassphrase",
-            "NewPreSharedKey",
-            "NewWEPKey0",
-            "NewWEPKey1",
-            "NewWEPKey2",
-            "NewWEPKey3",
-        ],
-        ("WLANConfiguration1", "X_AVM-DE_GetWLANDeviceListPath"): [
-            "NewX_AVM-DE_WLANDeviceListPath"
-        ],
-        ("WLANConfiguration1", "X_AVM-DE_GetWLANHybridMode"): ["NewBSSID", "NewSSID"],
-        ("WLANConfiguration2", "GetBSSID"): ["NewBSSID"],
-        ("WLANConfiguration2", "GetInfo"): ["NewBSSID", "NewSSID"],
-        ("WLANConfiguration2", "GetSSID"): ["NewSSID"],
-        ("WLANConfiguration2", "GetSecurityKeys"): [
-            "NewKeyPassphrase",
-            "NewPreSharedKey",
-            "NewWEPKey0",
-            "NewWEPKey1",
-            "NewWEPKey2",
-            "NewWEPKey3",
-        ],
-        ("WLANConfiguration2", "X_AVM-DE_GetWLANDeviceListPath"): [
-            "NewX_AVM-DE_WLANDeviceListPath"
-        ],
-        ("WLANConfiguration2", "X_AVM-DE_GetWLANHybridMode"): ["NewBSSID", "NewSSID"],
-        ("WLANConfiguration3", "GetBSSID"): ["NewBSSID"],
-        ("WLANConfiguration3", "GetInfo"): ["NewBSSID", "NewSSID"],
-        ("WLANConfiguration3", "GetSSID"): ["NewSSID"],
-        ("WLANConfiguration3", "GetSecurityKeys"): [
-            "NewKeyPassphrase",
-            "NewPreSharedKey",
-            "NewWEPKey0",
-            "NewWEPKey1",
-            "NewWEPKey2",
-            "NewWEPKey3",
-        ],
-        ("WLANConfiguration3", "X_AVM-DE_GetWLANDeviceListPath"): [
-            "NewX_AVM-DE_WLANDeviceListPath"
-        ],
-        ("WLANConfiguration3", "X_AVM-DE_GetWLANHybridMode"): ["NewBSSID", "NewSSID"],
-        ("WLANConfiguration4", "GetBSSID"): ["NewBSSID"],
-        ("WLANConfiguration4", "GetInfo"): ["NewBSSID", "NewSSID"],
-        ("WLANConfiguration4", "GetSSID"): ["NewSSID"],
-        ("WLANConfiguration4", "GetSecurityKeys"): [
-            "NewKeyPassphrase",
-            "NewPreSharedKey",
-            "NewWEPKey0",
-            "NewWEPKey1",
-            "NewWEPKey2",
-            "NewWEPKey3",
-        ],
-        ("WLANConfiguration4", "X_AVM-DE_GetWLANDeviceListPath"): [
-            "NewX_AVM-DE_WLANDeviceListPath"
-        ],
-        ("WLANConfiguration4", "X_AVM-DE_GetWLANHybridMode"): ["NewBSSID", "NewSSID"],
+        **{
+            (f"WLANConfiguration{i}", action): fields
+            for i in range(1, 5)
+            for action, fields in [
+                ("GetBSSID", ["NewBSSID"]),
+                ("GetInfo", ["NewBSSID", "NewSSID"]),
+                ("GetSSID", ["NewSSID"]),
+                ("GetSecurityKeys", ["NewKeyPassphrase", "NewPreSharedKey", "NewWEPKey0", "NewWEPKey1", "NewWEPKey2", "NewWEPKey3"]),
+                ("X_AVM-DE_GetWLANDeviceListPath", ["NewX_AVM-DE_WLANDeviceListPath"]),
+                ("X_AVM-DE_GetWLANHybridMode", ["NewBSSID", "NewSSID"]),
+            ]
+        },
         ("X_AVM-DE_AppSetup1", "GetAppRemoteInfo"): [
             "NewExternalIPAddress",
             "NewExternalIPv6Address",
@@ -240,11 +192,11 @@ def donate_data(
     action_results = {}
     for service, actions in services.items():
         for action in actions:
-            if "Get" in action and not (
+            if action.startswith("Get") and not (
                 "ByIP" in action
                 or "ByIndex" in action
-                or "GetSpecific" in action
-                or "GetGeneric" in action
+                or action.startswith("GetSpecific")
+                or action.startswith("GetGeneric")
             ):
                 res = safe_call_action(device, service, action)
                 action_results[(service, action)] = res

--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -860,10 +860,12 @@ class HostInfo(FritzCapability):
                         device.fc.call_action(svc, action)
                     elif action == "GetGenericHostEntry":
                         device.fc.call_action(svc, action, arguments={"NewIndex": 1})
+                    elif action == "X_AVM-DE_GetSpecificHostEntryByIP":
+                        device.fc.call_action(svc, action, arguments={"NewIPAddress": "0.0.0.0"})
                 except (FritzServiceError, FritzActionError, FritzInternalError) as e:
                     logger.warning(
                         "disabling metrics at service %s, action %s - "
-                        "fritzconnection.call_action returned %s}",
+                        "fritzconnection.call_action returned %s",
                         svc,
                         action,
                         str(e),


### PR DESCRIPTION
## Summary

Four independent fixes identified during a code review pass:

- **Logging correctness** (`config.py`): replace `logger.exception()` with `logger.error()` at all call sites outside `except` blocks (was emitting spurious `NoneType: None` tracebacks); collapse duplicated log+raise message strings; simplify `check_listen_address` validator
- **`data_donation` cleanup**: use `action.startswith("Get")` instead of `"Get" in action`; collapse 4× repeated `WLANConfiguration1–4` sanitization blacklist blocks into a single dict comprehension
- **`HostInfo` capability check**: the third requirement (`X_AVM-DE_GetSpecificHostEntryByIP`) was silently skipped by the `if/elif` chain and never test-called against the device; fix the stray `}` in the adjacent log format string
- **`asyncio` idle loop**: replace `asyncio.new_event_loop().run_forever()` (empty loop, nothing scheduled) with `threading.Event().wait()` — honest about the intent, removes unused `asyncio` import

## Test plan

- [ ] `uv run pytest` — 103 tests, all passing
- [ ] `uv run ruff check fritzexporter/` — no new violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)