### PR TITLE
refactor: code review phase 2 — capability lifecycle, WlanConfigurationInfo, HomeAutomation

### DIFF
--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -26,23 +26,17 @@ logger = logging.getLogger("fritzexporter.fritzcapability")
 
 
 class FritzCapability(ABC):
-    capabilities: ClassVar[list[type[FritzCapability]]] = []
     subclasses: ClassVar[list[type[FritzCapability]]] = []
 
     def __init__(self) -> None:
         self.present: bool = False
         self.requirements: list[tuple[str, str]] = []
         self.metrics: dict[str, CounterMetricFamily | GaugeMetricFamily] = {}
-        FritzCapability.register()
 
     def __init_subclass__(cls, **kwargs: dict[str, Any]) -> None:
         super().__init_subclass__(**kwargs)
         logger.debug("Capability subclass %s registered", cls.__name__)
         FritzCapability.subclasses.append(cls)
-
-    @classmethod
-    def register(cls) -> None:
-        FritzCapability.capabilities.append(cls)
 
     def check_capability(self, device: FritzDevice) -> None:
         self.present = all(
@@ -79,6 +73,7 @@ class FritzCapability(ABC):
     def get_metrics(
         self, devices: list[FritzDevice], name: str
     ) -> Iterator[CounterMetricFamily | GaugeMetricFamily]:
+        self.create_metrics()
         for device in devices:
             logger.debug(
                 "Fetching %s metrics for %s: %s",

--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -972,252 +972,94 @@ class HostInfo(FritzCapability):
 
 
 class HomeAutomation(FritzCapability):
+    _HA_LABELS: ClassVar[list[str]] = [
+        "serial", "friendly_name", "ain", "device_name", "device_id", "manufacturer", "productname",
+    ]
+    _DEVICE_PRESENT_MAP: ClassVar[dict[str, int]] = {
+        "DISCONNECTED": 0, "REGISTERED": 1, "CONNECTED": 2, "UNKNOWN": 3,
+    }
+    _SWITCH_MODE_MAP: ClassVar[dict[str, int]] = {"MANUAL": 0, "AUTO": 1, "UNDEFINED": 2}
+    _SWITCH_STATE_MAP: ClassVar[dict[str, int]] = {"OFF": 0, "ON": 1, "TOGGLE": 2, "UNDEFINED": 3}
+    _HKR_VALVE_MAP: ClassVar[dict[str, int]] = {"CLOSED": 0, "OPEN": 1, "TEMP": 2}
+
     def __init__(self) -> None:
         super().__init__()
         self.requirements.append(("X_AVM-DE_Homeauto1", "GetInfo"))
 
     def create_metrics(self) -> None:
-        self.metrics["devicepresent"] = GaugeMetricFamily(
-            "fritz_ha_device_present",
-            "Indicates that the device is present",
-            labels=[
-                "serial",
-                "friendly_name",
-                "ain",
-                "device_name",
-                "device_id",
-                "manufacturer",
-                "productname",
-            ],
-        )
+        labels = self._HA_LABELS
+        self.metrics["devicepresent"] = GaugeMetricFamily("fritz_ha_device_present", "Indicates that the device is present", labels=labels)
+        self.metrics["battery_level"] = GaugeMetricFamily("fritz_ha_battery_level_percent", "Battery level in percent", labels=labels)
+        self.metrics["battery_low"] = GaugeMetricFamily("fritz_ha_battery_low", "Indicates that the battery is low", labels=labels)
+        self.metrics["multimeter_power"] = GaugeMetricFamily("fritz_ha_multimeter_power_W", "Power in W", labels=labels)
+        self.metrics["multimeter_energy"] = GaugeMetricFamily("fritz_ha_multimeter_energy_Wh", "Energy in Wh", labels=labels)
+        self.metrics["temperature"] = GaugeMetricFamily("fritz_ha_temperature_C", "Temperature in °C", labels=labels)
+        self.metrics["temperature_offset"] = GaugeMetricFamily("fritz_ha_temperature_offset_C", "Temperature offset in °C", labels=labels)
+        self.metrics["switch_state"] = GaugeMetricFamily("fritz_ha_switch_state", "Switch state", labels=labels)
+        self.metrics["switch_mode"] = GaugeMetricFamily("fritz_ha_switch_mode", "Switch mode", labels=labels)
+        self.metrics["switch_lock"] = GaugeMetricFamily("fritz_ha_switch_lock", "Switch lock", labels=labels)
+        self.metrics["heater_temperature"] = GaugeMetricFamily("fritz_ha_heater_temperature_C", "Heater temperature in °C", labels=labels)
+        self.metrics["heater_set_temperature"] = GaugeMetricFamily("fritz_ha_heater_set_temperature_C", "Heater set temperature in °C", labels=labels)
+        self.metrics["heater_valve_set_state"] = GaugeMetricFamily("fritz_ha_heater_valve_set_state", "Heater valve set state", labels=labels)
+        self.metrics["heater_reduced_temperature"] = GaugeMetricFamily("fritz_ha_heater_reduced_temperature_C", "Heater reduced temperature in °C", labels=labels)
+        self.metrics["heater_comfort_temperature"] = GaugeMetricFamily("fritz_ha_heater_comfort_temperature_C", "Heater comfort temperature in °C", labels=labels)
+        self.metrics["heater_reduced_valve_state"] = GaugeMetricFamily("fritz_ha_heater_reduced_valve_state", "Heater reduced valve state", labels=labels)
+        self.metrics["heater_comfort_valve_state"] = GaugeMetricFamily("fritz_ha_heater_comfort_valve_state", "Heater comfort valve state", labels=labels)
 
-        self.metrics["battery_level"] = GaugeMetricFamily(
-            "fritz_ha_battery_level_percent",
-            "Battery level in percent",
-            labels=[
-                "serial",
-                "friendly_name",
-                "ain",
-                "device_name",
-                "device_id",
-                "manufacturer",
-                "productname",
-            ],
-        )
+    def _ha_labels(
+        self,
+        device: FritzDevice,
+        ain: str,
+        device_id: str,
+        device_name: str,
+        manufacturer: str,
+        productname: str,
+    ) -> list[str]:
+        return [device.serial, device.friendly_name, ain, device_name, device_id, manufacturer, productname]
 
-        self.metrics["battery_low"] = GaugeMetricFamily(
-            "fritz_ha_battery_low",
-            "Indicates that the battery is low",
-            labels=[
-                "serial",
-                "friendly_name",
-                "ain",
-                "device_name",
-                "device_id",
-                "manufacturer",
-                "productname",
-            ],
-        )
+    def _collect_multimeter(self, ha_result: dict[str, Any], labels: list[str]) -> None:
+        if ha_result["NewMultimeterIsEnabled"] == "ENABLED" and ha_result["NewMultimeterIsValid"] == "VALID":
+            self.metrics["multimeter_power"].add_metric(labels, ha_result["NewMultimeterPower"] / 100.0)
+            self.metrics["multimeter_energy"].add_metric(labels, ha_result["NewMultimeterEnergy"])
 
-        self.metrics["multimeter_power"] = GaugeMetricFamily(
-            "fritz_ha_multimeter_power_W",
-            "Power in W",
-            labels=[
-                "serial",
-                "friendly_name",
-                "ain",
-                "device_name",
-                "device_id",
-                "manufacturer",
-                "productname",
-            ],
-        )
-        self.metrics["multimeter_energy"] = GaugeMetricFamily(
-            "fritz_ha_multimeter_energy_Wh",
-            "Energy in Wh",
-            labels=[
-                "serial",
-                "friendly_name",
-                "ain",
-                "device_name",
-                "device_id",
-                "manufacturer",
-                "productname",
-            ],
-        )
-        self.metrics["temperature"] = GaugeMetricFamily(
-            "fritz_ha_temperature_C",
-            "Temperature in °C",
-            labels=[
-                "serial",
-                "friendly_name",
-                "ain",
-                "device_name",
-                "device_id",
-                "manufacturer",
-                "productname",
-            ],
-        )
-        self.metrics["temperature_offset"] = GaugeMetricFamily(
-            "fritz_ha_temperature_offset_C",
-            "Temperature offset in °C",
-            labels=[
-                "serial",
-                "friendly_name",
-                "ain",
-                "device_name",
-                "device_id",
-                "manufacturer",
-                "productname",
-            ],
-        )
-        self.metrics["switch_state"] = GaugeMetricFamily(
-            "fritz_ha_switch_state",
-            "Switch state",
-            labels=[
-                "serial",
-                "friendly_name",
-                "ain",
-                "device_name",
-                "device_id",
-                "manufacturer",
-                "productname",
-            ],
-        )
-        self.metrics["switch_mode"] = GaugeMetricFamily(
-            "fritz_ha_switch_mode",
-            "Switch mode",
-            labels=[
-                "serial",
-                "friendly_name",
-                "ain",
-                "device_name",
-                "device_id",
-                "manufacturer",
-                "productname",
-            ],
-        )
-        self.metrics["switch_lock"] = GaugeMetricFamily(
-            "fritz_ha_switch_lock",
-            "Switch lock",
-            labels=[
-                "serial",
-                "friendly_name",
-                "ain",
-                "device_name",
-                "device_id",
-                "manufacturer",
-                "productname",
-            ],
-        )
-        self.metrics["heater_temperature"] = GaugeMetricFamily(
-            "fritz_ha_heater_temperature_C",
-            "Heater temperature in °C",
-            labels=[
-                "serial",
-                "friendly_name",
-                "ain",
-                "device_name",
-                "device_id",
-                "manufacturer",
-                "productname",
-            ],
-        )
-        self.metrics["heater_set_temperature"] = GaugeMetricFamily(
-            "fritz_ha_heater_set_temperature_C",
-            "Heater set temperature in °C",
-            labels=[
-                "serial",
-                "friendly_name",
-                "ain",
-                "device_name",
-                "device_id",
-                "manufacturer",
-                "productname",
-            ],
-        )
-        self.metrics["heater_valve_set_state"] = GaugeMetricFamily(
-            "fritz_ha_heater_valve_set_state",
-            "Heater valve set state",
-            labels=[
-                "serial",
-                "friendly_name",
-                "ain",
-                "device_name",
-                "device_id",
-                "manufacturer",
-                "productname",
-            ],
-        )
-        self.metrics["heater_reduced_temperature"] = GaugeMetricFamily(
-            "fritz_ha_heater_reduced_temperature_C",
-            "Heater reduced temperature in °C",
-            labels=[
-                "serial",
-                "friendly_name",
-                "ain",
-                "device_name",
-                "device_id",
-                "manufacturer",
-                "productname",
-            ],
-        )
-        self.metrics["heater_comfort_temperature"] = GaugeMetricFamily(
-            "fritz_ha_heater_comfort_temperature_C",
-            "Heater comfort temperature in °C",
-            labels=[
-                "serial",
-                "friendly_name",
-                "ain",
-                "device_name",
-                "device_id",
-                "manufacturer",
-                "productname",
-            ],
-        )
-        self.metrics["heater_reduced_valve_state"] = GaugeMetricFamily(
-            "fritz_ha_heater_reduced_valve_state",
-            "Heater reduced valve state",
-            labels=[
-                "serial",
-                "friendly_name",
-                "ain",
-                "device_name",
-                "device_id",
-                "manufacturer",
-                "productname",
-            ],
-        )
-        self.metrics["heater_comfort_valve_state"] = GaugeMetricFamily(
-            "fritz_ha_heater_comfort_valve_state",
-            "Heater comfort valve state",
-            labels=[
-                "serial",
-                "friendly_name",
-                "ain",
-                "device_name",
-                "device_id",
-                "manufacturer",
-                "productname",
-            ],
-        )
+    def _collect_temperature(self, ha_result: dict[str, Any], labels: list[str]) -> None:
+        if ha_result["NewTemperatureIsEnabled"] == "ENABLED" and ha_result["NewTemperatureIsValid"] == "VALID":
+            self.metrics["temperature"].add_metric(labels, ha_result["NewTemperatureCelsius"] / 10.0)
+            self.metrics["temperature_offset"].add_metric(labels, ha_result["NewTemperatureOffset"] / 10.0)
 
-    def _generate_metric_values(self, device: FritzDevice) -> None:  # noqa: C901
-        # There is no way to get a list or the number of home automation devices, so we just try
-        # do a while loop until we get an error
+    def _collect_switch(self, ha_result: dict[str, Any], labels: list[str]) -> None:
+        if ha_result["NewSwitchIsEnabled"] == "ENABLED" and ha_result["NewSwitchIsValid"] == "VALID":
+            self.metrics["switch_state"].add_metric(labels, self._SWITCH_STATE_MAP[ha_result["NewSwitchState"]])
+            self.metrics["switch_mode"].add_metric(labels, self._SWITCH_MODE_MAP[ha_result["NewSwitchMode"]])
+            self.metrics["switch_lock"].add_metric(labels, 1 if ha_result["NewSwitchLock"] else 0)
+
+    def _collect_heater(self, ha_result: dict[str, Any], labels: list[str]) -> None:
+        if ha_result["NewHkrIsEnabled"] == "ENABLED" and ha_result["NewHkrIsValid"] == "VALID":
+            self.metrics["heater_temperature"].add_metric(labels, ha_result["NewHkrIsTemperature"] / 10.0)
+            self.metrics["heater_set_temperature"].add_metric(labels, ha_result["NewHkrSetTemperature"] / 10.0)
+            self.metrics["heater_valve_set_state"].add_metric(labels, self._HKR_VALVE_MAP[ha_result["NewHkrSetVentilStatus"]])
+            self.metrics["heater_reduced_temperature"].add_metric(labels, ha_result["NewHkrReduceTemperature"] / 10.0)
+            self.metrics["heater_comfort_temperature"].add_metric(labels, ha_result["NewHkrComfortTemperature"] / 10.0)
+            self.metrics["heater_reduced_valve_state"].add_metric(labels, self._HKR_VALVE_MAP[ha_result["NewHkrReduceVentilStatus"]])
+            self.metrics["heater_comfort_valve_state"].add_metric(labels, self._HKR_VALVE_MAP[ha_result["NewHkrComfortVentilStatus"]])
+
+    def _collect_battery(self, device: FritzDevice, ain: str, labels: list[str]) -> None:
+        # Battery data comes from the AHA HTTP API, not TR-064; "battery" XML element maps to "battery_level"
+        try:
+            http_result = device.fc.call_http("getdeviceinfos", ain)
+        except FritzHttpInterfaceError:
+            logger.debug("Got FritzHttpInterfaceError for ain %s, skipping", ain)
+            return
+        if "content" not in http_result:
+            return
+        http_data = parse_aha_device_xml(http_result["content"])
+        if "battery_level" in http_data:
+            self.metrics["battery_level"].add_metric(labels, float(http_data["battery_level"]))
+        if "battery_low" in http_data:
+            self.metrics["battery_low"].add_metric(labels, 1 if http_data["battery_low"] == "1" else 0)
+
+    def _generate_metric_values(self, device: FritzDevice) -> None:
         index = 0
-
-        device_present_map = {
-            "DISCONNECTED": 0,
-            "REGISTERED": 1,
-            "CONNECTED": 2,
-            "UNKNOWN": 3,
-        }
-
-        switch_mode_map = {"MANUAL": 0, "AUTO": 1, "UNDEFINED": 2}
-        switch_state_map = {"OFF": 0, "ON": 1, "TOGGLE": 2, "UNDEFINED": 3}
-        hkr_valve_map = {"CLOSED": 0, "OPEN": 1, "TEMP": 2}
-
         while True:
             logger.debug("Fetching home automation device information for index %d", index)
             try:
@@ -1233,233 +1075,15 @@ class HomeAutomation(FritzCapability):
             device_name = ha_result["NewDeviceName"]
             manufacturer = ha_result["NewManufacturer"]
             productname = ha_result["NewProductName"]
+            labels = self._ha_labels(device, ain, device_id, device_name, manufacturer, productname)
 
-            self.metrics["devicepresent"].add_metric(
-                [device.serial, device.friendly_name, ain, device_name, device_id, manufacturer, productname],
-                device_present_map[ha_result["NewPresent"]],
-            )
-
-            if (
-                ha_result["NewMultimeterIsEnabled"] == "ENABLED"
-                and ha_result["NewMultimeterIsValid"] == "VALID"
-            ):
-                self.metrics["multimeter_power"].add_metric(
-                    [
-                        device.serial,
-                        device.friendly_name,
-                        ain,
-                        device_name,
-                        device_id,
-                        manufacturer,
-                        productname,
-                    ],
-                    ha_result["NewMultimeterPower"] / 100.0,
-                )
-                self.metrics["multimeter_energy"].add_metric(
-                    [
-                        device.serial,
-                        device.friendly_name,
-                        ain,
-                        device_name,
-                        device_id,
-                        manufacturer,
-                        productname,
-                    ],
-                    ha_result["NewMultimeterEnergy"],
-                )
-
-            if (
-                ha_result["NewTemperatureIsEnabled"] == "ENABLED"
-                and ha_result["NewTemperatureIsValid"] == "VALID"
-            ):
-                self.metrics["temperature"].add_metric(
-                    [
-                        device.serial,
-                        device.friendly_name,
-                        ain,
-                        device_name,
-                        device_id,
-                        manufacturer,
-                        productname,
-                    ],
-                    ha_result["NewTemperatureCelsius"] / 10.0,
-                )
-                self.metrics["temperature_offset"].add_metric(
-                    [
-                        device.serial,
-                        device.friendly_name,
-                        ain,
-                        device_name,
-                        device_id,
-                        manufacturer,
-                        productname,
-                    ],
-                    ha_result["NewTemperatureOffset"] / 10.0,
-                )
-
-            if (
-                ha_result["NewSwitchIsEnabled"] == "ENABLED"
-                and ha_result["NewSwitchIsValid"] == "VALID"
-            ):
-                self.metrics["switch_state"].add_metric(
-                    [
-                        device.serial,
-                        device.friendly_name,
-                        ain,
-                        device_name,
-                        device_id,
-                        manufacturer,
-                        productname,
-                    ],
-                    switch_state_map[ha_result["NewSwitchState"]],
-                )
-                self.metrics["switch_mode"].add_metric(
-                    [
-                        device.serial,
-                        device.friendly_name,
-                        ain,
-                        device_name,
-                        device_id,
-                        manufacturer,
-                        productname,
-                    ],
-                    switch_mode_map[ha_result["NewSwitchMode"]],
-                )
-                self.metrics["switch_lock"].add_metric(
-                    [
-                        device.serial,
-                        device.friendly_name,
-                        ain,
-                        device_name,
-                        device_id,
-                        manufacturer,
-                        productname,
-                    ],
-                    1 if ha_result["NewSwitchLock"] else 0,
-                )
-
-            if ha_result["NewHkrIsEnabled"] == "ENABLED" and ha_result["NewHkrIsValid"] == "VALID":
-                self.metrics["heater_temperature"].add_metric(
-                    [
-                        device.serial,
-                        device.friendly_name,
-                        ain,
-                        device_name,
-                        device_id,
-                        manufacturer,
-                        productname,
-                    ],
-                    ha_result["NewHkrIsTemperature"] / 10.0,
-                )
-                self.metrics["heater_set_temperature"].add_metric(
-                    [
-                        device.serial,
-                        device.friendly_name,
-                        ain,
-                        device_name,
-                        device_id,
-                        manufacturer,
-                        productname,
-                    ],
-                    ha_result["NewHkrSetTemperature"] / 10.0,
-                )
-                self.metrics["heater_valve_set_state"].add_metric(
-                    [
-                        device.serial,
-                        device.friendly_name,
-                        ain,
-                        device_name,
-                        device_id,
-                        manufacturer,
-                        productname,
-                    ],
-                    hkr_valve_map[ha_result["NewHkrSetVentilStatus"]],
-                )
-                self.metrics["heater_reduced_temperature"].add_metric(
-                    [
-                        device.serial,
-                        device.friendly_name,
-                        ain,
-                        device_name,
-                        device_id,
-                        manufacturer,
-                        productname,
-                    ],
-                    ha_result["NewHkrReduceTemperature"] / 10.0,
-                )
-                self.metrics["heater_comfort_temperature"].add_metric(
-                    [
-                        device.serial,
-                        device.friendly_name,
-                        ain,
-                        device_name,
-                        device_id,
-                        manufacturer,
-                        productname,
-                    ],
-                    ha_result["NewHkrComfortTemperature"] / 10.0,
-                )
-                self.metrics["heater_reduced_valve_state"].add_metric(
-                    [
-                        device.serial,
-                        device.friendly_name,
-                        ain,
-                        device_name,
-                        device_id,
-                        manufacturer,
-                        productname,
-                    ],
-                    hkr_valve_map[ha_result["NewHkrReduceVentilStatus"]],
-                )
-                self.metrics["heater_comfort_valve_state"].add_metric(
-                    [
-                        device.serial,
-                        device.friendly_name,
-                        ain,
-                        device_name,
-                        device_id,
-                        manufacturer,
-                        productname,
-                    ],
-                    hkr_valve_map[ha_result["NewHkrComfortVentilStatus"]],
-                )
-
+            self.metrics["devicepresent"].add_metric(labels, self._DEVICE_PRESENT_MAP[ha_result["NewPresent"]])
+            self._collect_multimeter(ha_result, labels)
+            self._collect_temperature(ha_result, labels)
+            self._collect_switch(ha_result, labels)
+            self._collect_heater(ha_result, labels)
             index += 1
-
-            try:
-                http_result = device.fc.call_http("getdeviceinfos", ain)
-            except FritzHttpInterfaceError:
-                logger.debug("Got FritzHttpInterfaceError for ain %s, skipping", ain)
-                continue
-
-            if "content" in http_result:
-                http_data = parse_aha_device_xml(http_result["content"])
-                # AHA XML parses battery percentage under key "battery_level" (not "battery")
-                if "battery_level" in http_data:
-                    self.metrics["battery_level"].add_metric(
-                        [
-                            device.serial,
-                            device.friendly_name,
-                            ain,
-                            device_name,
-                            manufacturer,
-                            productname,
-                        ],
-                        float(http_data["battery_level"]),
-                    )
-
-                if "battery_low" in http_data:
-                    self.metrics["battery_low"].add_metric(
-                        [
-                            device.serial,
-                            device.friendly_name,
-                            ain,
-                            device_name,
-                            manufacturer,
-                            productname,
-                        ],
-                        1 if http_data["battery_low"] == "1" else 0,
-                    )
+            self._collect_battery(device, ain, labels)
 
     def _get_metric_values(
         self,

--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -1229,12 +1229,13 @@ class HomeAutomation(FritzCapability):
                 break
 
             ain = ha_result["NewAIN"]
+            device_id = str(ha_result["NewDeviceId"])
             device_name = ha_result["NewDeviceName"]
             manufacturer = ha_result["NewManufacturer"]
             productname = ha_result["NewProductName"]
 
             self.metrics["devicepresent"].add_metric(
-                [device.serial, device.friendly_name, ain, device_name, manufacturer, productname],
+                [device.serial, device.friendly_name, ain, device_name, device_id, manufacturer, productname],
                 device_present_map[ha_result["NewPresent"]],
             )
 
@@ -1248,6 +1249,7 @@ class HomeAutomation(FritzCapability):
                         device.friendly_name,
                         ain,
                         device_name,
+                        device_id,
                         manufacturer,
                         productname,
                     ],
@@ -1259,6 +1261,7 @@ class HomeAutomation(FritzCapability):
                         device.friendly_name,
                         ain,
                         device_name,
+                        device_id,
                         manufacturer,
                         productname,
                     ],
@@ -1275,6 +1278,7 @@ class HomeAutomation(FritzCapability):
                         device.friendly_name,
                         ain,
                         device_name,
+                        device_id,
                         manufacturer,
                         productname,
                     ],
@@ -1286,6 +1290,7 @@ class HomeAutomation(FritzCapability):
                         device.friendly_name,
                         ain,
                         device_name,
+                        device_id,
                         manufacturer,
                         productname,
                     ],
@@ -1302,6 +1307,7 @@ class HomeAutomation(FritzCapability):
                         device.friendly_name,
                         ain,
                         device_name,
+                        device_id,
                         manufacturer,
                         productname,
                     ],
@@ -1313,6 +1319,7 @@ class HomeAutomation(FritzCapability):
                         device.friendly_name,
                         ain,
                         device_name,
+                        device_id,
                         manufacturer,
                         productname,
                     ],
@@ -1324,6 +1331,7 @@ class HomeAutomation(FritzCapability):
                         device.friendly_name,
                         ain,
                         device_name,
+                        device_id,
                         manufacturer,
                         productname,
                     ],
@@ -1337,6 +1345,7 @@ class HomeAutomation(FritzCapability):
                         device.friendly_name,
                         ain,
                         device_name,
+                        device_id,
                         manufacturer,
                         productname,
                     ],
@@ -1348,6 +1357,7 @@ class HomeAutomation(FritzCapability):
                         device.friendly_name,
                         ain,
                         device_name,
+                        device_id,
                         manufacturer,
                         productname,
                     ],
@@ -1359,6 +1369,7 @@ class HomeAutomation(FritzCapability):
                         device.friendly_name,
                         ain,
                         device_name,
+                        device_id,
                         manufacturer,
                         productname,
                     ],
@@ -1370,6 +1381,7 @@ class HomeAutomation(FritzCapability):
                         device.friendly_name,
                         ain,
                         device_name,
+                        device_id,
                         manufacturer,
                         productname,
                     ],
@@ -1381,6 +1393,7 @@ class HomeAutomation(FritzCapability):
                         device.friendly_name,
                         ain,
                         device_name,
+                        device_id,
                         manufacturer,
                         productname,
                     ],
@@ -1392,6 +1405,7 @@ class HomeAutomation(FritzCapability):
                         device.friendly_name,
                         ain,
                         device_name,
+                        device_id,
                         manufacturer,
                         productname,
                     ],
@@ -1403,6 +1417,7 @@ class HomeAutomation(FritzCapability):
                         device.friendly_name,
                         ain,
                         device_name,
+                        device_id,
                         manufacturer,
                         productname,
                     ],

--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -624,14 +624,15 @@ class WanCommonInterfaceDataPackets(FritzCapability):
 
 
 class WlanConfigurationInfo(FritzCapability):
+    WIFI_NAMES: ClassVar[list[str]] = ["2.4GHz", "5GHz", "Guest", "WLAN4"]
+
     def __init__(self) -> None:
         super().__init__()
-        self.wifi_type = ["2.4GHz", "5GHz", "Guest", "WLAN4"]
-        self.wifi_present = [False, False, False, False]
+        self.wifi_present: list[bool] = [False] * len(self.WIFI_NAMES)
 
     def check_capability(self, device: FritzDevice) -> None:
-        for wlan in range(len(self.wifi_present)):
-            service = f"WLANConfiguration{wlan + 1}"
+        for index in range(len(self.WIFI_NAMES)):
+            service = f"WLANConfiguration{index + 1}"
             requirements = [
                 (service, "GetInfo"),
                 (service, "GetTotalAssociations"),
@@ -640,18 +641,18 @@ class WlanConfigurationInfo(FritzCapability):
             logger.debug(
                 "Capability %s checking %s on %s", type(self).__name__, service, device.host
             )
-            self.wifi_present[wlan] = all(
+            self.wifi_present[index] = all(
                 (service in device.fc.services) and (action in device.fc.services[service].actions)
                 for (service, action) in requirements
             )
             logger.debug(
                 "Capability %s in WLAN %d set to %s on device %s",
                 type(self).__name__,
-                wlan + 1,
-                self.wifi_present[wlan],
+                index + 1,
+                self.wifi_present[index],
                 device.host,
             )
-            if self.wifi_present[wlan]:
+            if self.wifi_present[index]:
                 for svc, action in requirements:
                     try:
                         device.fc.call_action(svc, action)
@@ -667,7 +668,7 @@ class WlanConfigurationInfo(FritzCapability):
                             action,
                             str(e),
                         )
-                        self.wifi_present[wlan] = False
+                        self.wifi_present[index] = False
         self.present = any(self.wifi_present)
 
     def create_metrics(self) -> None:
@@ -733,14 +734,15 @@ class WlanConfigurationInfo(FritzCapability):
             device.host,
             self.__class__.__name__,
         )
-        for index, wlan in enumerate(cast(WlanConfigurationInfo, device.capabilities[self.__class__.__name__]).wifi_present):
+        device_wlan_cap = cast(WlanConfigurationInfo, device.capabilities[self.__class__.__name__])
+        for index, wlan_present in enumerate(device_wlan_cap.wifi_present):
             logger.debug(
                 "WLANConfigurationInfo._generateMetricValues checking WLAN %s (enabled: %s) on %s",
                 index,
-                wlan,
+                wlan_present,
                 device.host,
             )
-            if wlan:
+            if wlan_present:
                 logger.debug(
                     "WLANCapability._generateMetricValues fetching metrics for %s: %s",
                     device.host,
@@ -757,7 +759,7 @@ class WlanConfigurationInfo(FritzCapability):
                         wlan_result["NewStandard"],
                         wlan_result["NewSSID"],
                         str(index + 1),
-                        self.wifi_type[index],
+                        self.WIFI_NAMES[index],
                     ],
                     wlan_status,
                 )
@@ -769,7 +771,7 @@ class WlanConfigurationInfo(FritzCapability):
                         wlan_result["NewStandard"],
                         wlan_result["NewSSID"],
                         str(index + 1),
-                        self.wifi_type[index],
+                        self.WIFI_NAMES[index],
                     ],
                     wlan_result["NewChannel"],
                 )
@@ -785,7 +787,7 @@ class WlanConfigurationInfo(FritzCapability):
                         wlan_result["NewStandard"],
                         wlan_result["NewSSID"],
                         str(index + 1),
-                        self.wifi_type[index],
+                        self.WIFI_NAMES[index],
                     ],
                     assoc_results["NewTotalAssociations"],
                 )
@@ -802,7 +804,7 @@ class WlanConfigurationInfo(FritzCapability):
                         wlan_result["NewSSID"],
                         "rx",
                         str(index + 1),
-                        self.wifi_type[index],
+                        self.WIFI_NAMES[index],
                     ],
                     packet_stats_result["NewTotalPacketsReceived"],
                 )
@@ -815,7 +817,7 @@ class WlanConfigurationInfo(FritzCapability):
                         wlan_result["NewSSID"],
                         "tx",
                         str(index + 1),
-                        self.wifi_type[index],
+                        self.WIFI_NAMES[index],
                     ],
                     packet_stats_result["NewTotalPacketsSent"],
                 )

--- a/fritzexporter/fritzdevice.py
+++ b/fritzexporter/fritzdevice.py
@@ -183,7 +183,6 @@ class FritzCollector(Collector):
                     collected.append(mode_metric)
 
             for name, capa in self.capabilities.items():
-                capa.create_metrics()
                 collected.extend(list(capa.get_metrics(self.devices, name)))
 
             # Yield device availability metric for all known devices


### PR DESCRIPTION
## Summary

Four refactoring and fix commits identified during a code review pass:

- **Capability lifecycle cleanup**: remove dead `FritzCapability.register()` classmethod and `capabilities` ClassVar (accumulated on every instantiation but never read — `subclasses` via `__init_subclass__` was always the authoritative list); move `create_metrics()` reset from `FritzCollector.collect()` into `FritzCapability.get_metrics()` so the reset is an internal invariant rather than a caller obligation
- **`WlanConfigurationInfo` cleanup**: promote `wifi_type` instance list to `WIFI_NAMES` ClassVar (it is a fixed constant); replace `[False, False, False, False]` initialiser with `[False] * len(self.WIFI_NAMES)` + explicit annotation; rename ambiguous `wlan` loop variable to `index`; extract the inline `cast()` to a named variable before the `enumerate`
- **`HomeAutomation` label bug fix** ⚠️ _see breaking change note below_: `create_metrics()` declared `device_id` as the 5th label in all 17 metric families, but `_generate_metric_values()` was passing only 6 values — `device_id` was silently emitted as `""` and `manufacturer`/`productname` were misaligned
- **`HomeAutomation` decomposition**: promote four lookup dicts to class-level `ClassVar` constants; add `_HA_LABELS` ClassVar to eliminate 17 identical label list repetitions in `create_metrics()`; add `_ha_labels()` helper; extract `_collect_multimeter()`, `_collect_temperature()`, `_collect_switch()`, `_collect_heater()`, `_collect_battery()` — `_generate_metric_values()` becomes a clean loop; `# noqa: C901` removed

## ⚠️ Breaking change

`fritz_ha_*` Prometheus metrics now include a **populated `device_id` label**. Previously this label was always `""` due to the bug; it now carries the real `NewDeviceId` value from the Fritz!Box. Prometheus treats changed label sets as new time series, so existing HA metric series will reset on the first scrape after upgrading. Any dashboards or alerts filtering on `device_id=""` will stop matching. Migration notes will be added to `docs/upgrading.rst` in the follow-up breaking-changes PR (which will also change the default `listen_address` from `0.0.0.0` to `127.0.0.1`).

## Test plan

- [ ] `uv run pytest` — 103 tests, all passing
- [ ] `uv run ruff check fritzexporter/` — no new violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)