### PR TITLE
ops: pin sonarqube-scan-action to v8.1.0

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -44,7 +44,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
           exit $rescode
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@master
+        uses: SonarSource/sonarqube-scan-action@v8.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary

Pin `sonarqube-scan-action` to an explicit release tag (`v8.1.0`) rather than floating on `@master`. Good hygiene regardless of the intermittent CDN issue — avoids surprise behaviour changes from unannounced action updates.

The SonarCloud 403 CDN errors are intermittent and typically resolve on a manual retry; no further changes needed for now.

## Test plan
- [ ] CI passes on this PR
- [ ] SonarCloud scan completes (may need a manual retry if CDN is flaky)

🤖 Generated with [Claude Code](https://claude.com/claude-code)