### PR TITLE
fix: handle FritzLookUpError in HostInfo capability probe

### DIFF
--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -13,6 +13,7 @@ from fritzconnection.core.exceptions import (  # type: ignore[import]
     FritzConnectionException,
     FritzHttpInterfaceError,
     FritzInternalError,
+    FritzLookUpError,
     FritzServiceError,
 )
 from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
@@ -858,7 +859,10 @@ class HostInfo(FritzCapability):
                     elif action == "GetGenericHostEntry":
                         device.fc.call_action(svc, action, arguments={"NewIndex": 1})
                     elif action == "X_AVM-DE_GetSpecificHostEntryByIP":
-                        device.fc.call_action(svc, action, arguments={"NewIPAddress": "0.0.0.0"})
+                        try:
+                            device.fc.call_action(svc, action, arguments={"NewIPAddress": "0.0.0.0"})
+                        except FritzLookUpError:
+                            pass  # 714 NoSuchEntryInArray — action works, 0.0.0.0 not in host table
                 except (FritzServiceError, FritzActionError, FritzInternalError) as e:
                     logger.warning(
                         "disabling metrics at service %s, action %s - "

--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -839,6 +839,31 @@ class HostInfo(FritzCapability):
         self.requirements.append(("Hosts1", "GetGenericHostEntry"))
         self.requirements.append(("Hosts1", "X_AVM-DE_GetSpecificHostEntryByIP"))
 
+    def _probe_specific_host_entry(self, device: FritzDevice, svc: str, action: str) -> None:
+        try:
+            device.fc.call_action(svc, action, arguments={"NewIPAddress": "0.0.0.0"})
+        except FritzLookUpError:
+            pass  # 714 NoSuchEntryInArray — action works, 0.0.0.0 not in host table
+
+    def _probe_action(self, device: FritzDevice, svc: str, action: str) -> bool:
+        try:
+            if action == "GetHostNumberOfEntries":
+                device.fc.call_action(svc, action)
+            elif action == "GetGenericHostEntry":
+                device.fc.call_action(svc, action, arguments={"NewIndex": 1})
+            elif action == "X_AVM-DE_GetSpecificHostEntryByIP":
+                self._probe_specific_host_entry(device, svc, action)
+        except (FritzServiceError, FritzActionError, FritzInternalError) as e:
+            logger.warning(
+                "disabling metrics at service %s, action %s - "
+                "fritzconnection.call_action returned %s",
+                svc,
+                action,
+                str(e),
+            )
+            return False
+        return True
+
     def check_capability(self, device: FritzDevice) -> None:
         self.present = device.host_info and all(
             (service in device.fc.services) and (action in device.fc.services[service].actions)
@@ -847,30 +872,9 @@ class HostInfo(FritzCapability):
         logger.debug(
             "Capability %s set to %s on device %s", type(self).__name__, self.present, device.host
         )
-
-        # It seems some boxes report service/actions they don't actually support.
-        # So try calling the requirements, and if it throws "InvalidService",
-        # "InvalidAction" or "FritzInternalError" disable this again.
         if self.present:
             for svc, action in self.requirements:
-                try:
-                    if action == "GetHostNumberOfEntries":
-                        device.fc.call_action(svc, action)
-                    elif action == "GetGenericHostEntry":
-                        device.fc.call_action(svc, action, arguments={"NewIndex": 1})
-                    elif action == "X_AVM-DE_GetSpecificHostEntryByIP":
-                        try:
-                            device.fc.call_action(svc, action, arguments={"NewIPAddress": "0.0.0.0"})
-                        except FritzLookUpError:
-                            pass  # 714 NoSuchEntryInArray — action works, 0.0.0.0 not in host table
-                except (FritzServiceError, FritzActionError, FritzInternalError) as e:
-                    logger.warning(
-                        "disabling metrics at service %s, action %s - "
-                        "fritzconnection.call_action returned %s",
-                        svc,
-                        action,
-                        str(e),
-                    )
+                if not self._probe_action(device, svc, action):
                     self.present = False
 
     def create_metrics(self) -> None:


### PR DESCRIPTION
## Summary

When probing `X_AVM-DE_GetSpecificHostEntryByIP` with `0.0.0.0` during capability detection, a Fritz!Box returns UPnP error 714 (`NoSuchEntryInArray`) as `FritzLookUpError` if that IP is not currently in its host table. This is the correct and expected response — it confirms the action is callable — but `FritzLookUpError` was missing from the `except` clause, causing it to propagate up and register the device as offline on startup.

The failure was intermittent: `REGISTRY.register(fritzcollector)` triggers `collect()` (prometheus_client uses `collect()` as the describe function when `auto_describe=True` and no `describe()` method exists), which immediately retries offline devices. The retry succeeded whenever `0.0.0.0` happened to be present in the Fritz!Box host table at that moment.

Fix: catch `FritzLookUpError` specifically for the `X_AVM-DE_GetSpecificHostEntryByIP` probe call and treat it as confirmation that the capability is supported.

## Test plan
- [x] `uv run pytest` — 103 tests, all passing
- [x] Smoke test: exporter starts cleanly against a real device without registering it as offline

🤖 Generated with [Claude Code](https://claude.com/claude-code)