### PR TITLE
fix: resolve SonarCloud issues — naming clash, complexity, literal duplication

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__sonarqube__search_my_sonarqube_projects"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ fritz-mixin/vendor/**
 requirements.txt
 .DS_Store
 
+# Claude Code local settings (personal allowlists etc.)
+.claude/settings.local.json
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "sonarqube": {
+      "command": "sonar",
+      "args": [
+        "run",
+        "mcp",
+        "--project",
+        "pdreker_fritz_exporter"
+      ]
+    }
+  }
+}

--- a/fritzexporter/__main__.py
+++ b/fritzexporter/__main__.py
@@ -12,7 +12,7 @@ from fritzconnection.core.exceptions import (  # type: ignore[import]
 from prometheus_client import start_http_server
 from prometheus_client.core import REGISTRY
 
-from fritzexporter.config import ExporterError, get_config
+from fritzexporter.config import DeviceConfig, ExporterError, get_config
 from fritzexporter.data_donation import donate_data
 from fritzexporter.exceptions import FritzDeviceHasNoCapabilitiesError
 from fritzexporter.fritzdevice import FritzCollector, FritzCredentials, FritzDevice
@@ -69,6 +69,39 @@ def parse_cmdline() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def _resolve_password(dev: DeviceConfig) -> str:
+    if dev.password_file is not None:
+        password = Path(dev.password_file).read_text().strip()
+        logger.info("Using password from password file %s", dev.password_file)
+    else:
+        password = dev.password if dev.password is not None else ""
+    return password
+
+
+def _register_device(
+    dev: DeviceConfig, args: argparse.Namespace, fritzcollector: FritzCollector
+) -> None:
+    password = _resolve_password(dev)
+    creds = FritzCredentials(dev.hostname, dev.username, password)
+    try:
+        fritz_device = FritzDevice(creds, dev.name, host_info=dev.host_info)
+    except (FritzConnectionException, FritzAuthorizationError, FritzDeviceHasNoCapabilitiesError):
+        logger.exception(
+            "Failed to initialize device %s (%s), it will be reported as down",
+            dev.hostname,
+            dev.name,
+        )
+        fritzcollector.register_offline(creds, dev.name, host_info=dev.host_info)
+        return
+
+    if args.donate_data == "donate":
+        donate_data(fritz_device, upload=args.upload_data == "upload", sanitation=args.sanitize)
+        sys.exit(0)
+    else:
+        logger.info("registering %s to collector", dev.hostname)
+        fritzcollector.register(fritz_device)
+
+
 def main() -> None:
     fritzcollector = FritzCollector()
 
@@ -95,43 +128,7 @@ def main() -> None:
         log.setLevel(log_level)
 
     for dev in config.devices:
-        if dev.password_file is not None:
-            # read password from password file, strip to get rid of newlines
-            password = Path(dev.password_file).read_text().strip()
-            logger.info("Using password from password file %s", dev.password_file)
-        else:
-            password = dev.password if dev.password is not None else ""
-
-        creds = FritzCredentials(dev.hostname, dev.username, password)
-        try:
-            fritz_device = FritzDevice(
-                creds,
-                dev.name,
-                host_info=dev.host_info,
-            )
-        except (
-            FritzConnectionException,
-            FritzAuthorizationError,
-            FritzDeviceHasNoCapabilitiesError,
-        ):
-            logger.exception(
-                "Failed to initialize device %s (%s), it will be reported as down",
-                dev.hostname,
-                dev.name,
-            )
-            fritzcollector.register_offline(creds, dev.name, host_info=dev.host_info)
-            continue
-
-        if args.donate_data == "donate":
-            donate_data(
-                fritz_device,
-                upload=args.upload_data == "upload",
-                sanitation=args.sanitize,
-            )
-            sys.exit(0)
-        else:
-            logger.info("registering %s to collector", dev.hostname)
-            fritzcollector.register(fritz_device)
+        _register_device(dev, args, fritzcollector)
 
     REGISTRY.register(fritzcollector)
 

--- a/fritzexporter/data_donation.py
+++ b/fritzexporter/data_donation.py
@@ -19,6 +19,91 @@ from .fritzdevice import FritzDevice
 
 logger = logging.getLogger("fritzexporter.donate_data")
 
+_SANITIZED = "<SANITIZED>"
+
+_SANITIZATION_BLACKLIST: dict[tuple[str, str], list[str]] = {
+    ("DeviceConfig1", "GetPersistentData"): ["NewPersistentData"],
+    ("DeviceConfig1", "X_AVM-DE_GetConfigFile"): ["NewConfigFile"],
+    ("DeviceInfo1", "GetDeviceLog"): ["NewDeviceLog"],
+    ("DeviceConfig1", "X_AVM-DE_GetSupportDataInfo"): ["NewX_AVM-DE_SupportDataID"],
+    ("DeviceInfo1", "GetInfo"): ["NewDeviceLog", "NewProvisioningCode", "NewSerialNumber"],
+    ("DeviceInfo1", "GetSecurityPort"): ["NewSecurityPort"],
+    ("Hosts1", "X_AVM-DE_GetHostListPath"): ["NewX_AVM-DE_HostListPath"],
+    ("Hosts1", "X_AVM-DE_GetMeshListPath"): ["NewX_AVM-DE_MeshListPath"],
+    ("LANConfigSecurity1", "X_AVM-DE_GetCurrentUser"): [
+        "NewX_AVM-DE_CurrentUserRights",
+        "NewX_AVM-DE_CurrentUsername",
+    ],
+    ("LANConfigSecurity1", "X_AVM-DE_GetUserList"): ["NewX_AVM-DE_UserList"],
+    ("LANEthernetInterfaceConfig1", "GetInfo"): ["NewMACAddress"],
+    ("LANHostConfigManagement1", "GetAddressRange"): ["NewMaxAddress", "NewMinAddress"],
+    ("LANHostConfigManagement1", "GetDNSServers"): ["NewDNSServers"],
+    ("LANHostConfigManagement1", "GetIPRoutersList"): ["NewIPRouters"],
+    ("LANHostConfigManagement1", "GetInfo"): [
+        "NewDNSServers",
+        "NewIPRouters",
+        "NewMaxAddress",
+        "NewMinAddress",
+    ],
+    ("ManagementServer1", "GetInfo"): ["NewUsername", "NewConnectionRequestURL"],
+    ("Time1", "GetInfo"): ["NewNTPServer1", "NewNTPServer2"],
+    ("WANCommonIFC1", "GetAddonInfos"): [
+        "NewDNSServer1",
+        "NewDNSServer2",
+        "NewVoipDNSServer1",
+        "NewVoipDNSServer2",
+    ],
+    ("WANIPConn1", "GetExternalIPAddress"): ["NewExternalIPAddress"],
+    ("WANIPConn1", "X_AVM_DE_GetDNSServer"): ["NewIPv4DNSServer1", "NewIPv4DNSServer2"],
+    ("WANIPConn1", "X_AVM_DE_GetExternalIPv6Address"): ["NewExternalIPv6Address"],
+    ("WANIPConn1", "X_AVM_DE_GetIPv6DNSServer"): ["NewIPv6DNSServer1", "NewIPv6DNSServer2"],
+    ("WANIPConn1", "X_AVM_DE_GetIPv6Prefix"): ["NewIPv6Prefix"],
+    ("WANIPConnection1", "GetExternalIPAddress"): ["NewExternalIPAddress"],
+    ("WANIPConnection1", "GetInfo"): ["NewDNSServers", "NewMACAddress", "NewExternalIPAddress"],
+    ("WANIPConnection1", "X_GetDNSServers"): ["NewDNSServers"],
+    ("WANPPPConnection1", "GetExternalIPAddress"): ["NewExternalIPAddress"],
+    ("WANPPPConnection1", "GetInfo"): [
+        "NewDNSServers",
+        "NewExternalIPAddress",
+        "NewMACAddress",
+        "NewUserName",
+    ],
+    ("WANPPPConnection1", "GetUserName"): ["NewUserName"],
+    ("WANPPPConnection1", "X_GetDNSServers"): ["NewDNSServers"],
+    **{
+        (f"WLANConfiguration{i}", action): fields
+        for i in range(1, 5)
+        for action, fields in [
+            ("GetBSSID", ["NewBSSID"]),
+            ("GetInfo", ["NewBSSID", "NewSSID"]),
+            ("GetSSID", ["NewSSID"]),
+            ("GetSecurityKeys", ["NewKeyPassphrase", "NewPreSharedKey", "NewWEPKey0", "NewWEPKey1", "NewWEPKey2", "NewWEPKey3"]),
+            ("X_AVM-DE_GetWLANDeviceListPath", ["NewX_AVM-DE_WLANDeviceListPath"]),
+            ("X_AVM-DE_GetWLANHybridMode", ["NewBSSID", "NewSSID"]),
+        ]
+    },
+    ("X_AVM-DE_AppSetup1", "GetAppRemoteInfo"): [
+        "NewExternalIPAddress",
+        "NewExternalIPv6Address",
+        "NewIPAddress",
+        "NewMyFritzDynDNSName",
+        "NewRemoteAccessDDNSDomain",
+    ],
+    ("X_AVM-DE_Dect1", "GetDectListPath"): ["NewDectListPath"],
+    ("X_AVM-DE_Filelinks1", "GetFilelinkListPath"): ["NewFilelinkListPath"],
+    ("X_AVM-DE_MyFritz1", "GetInfo"): ["NewDynDNSName", "NewPort"],
+    ("X_AVM-DE_OnTel1", "GetCallBarringList"): ["NewPhonebookURL"],
+    ("X_AVM-DE_OnTel1", "GetCallList"): ["NewCallListURL"],
+    ("X_AVM-DE_OnTel1", "GetDECTHandsetList"): ["NewDectIDList"],
+    ("X_AVM-DE_OnTel1", "GetDeflections"): ["NewDeflectionList"],
+    ("X_AVM-DE_RemoteAccess1", "GetDDNSInfo"): ["NewDomain", "NewUpdateURL", "NewUsername"],
+    ("X_AVM-DE_RemoteAccess1", "GetInfo"): ["NewPort", "NewUsername"],
+    ("X_AVM-DE_Storage1", "GetUserInfo"): ["NewUsername"],
+    ("X_AVM-DE_TAM1", "GetList"): ["NewTAMList"],
+    ("X_VoIP1", "X_AVM-DE_GetClients"): ["NewX_AVM-DE_ClientList"],
+    ("X_VoIP1", "X_AVM-DE_GetNumbers"): ["NewNumberList"],
+}
+
 
 def get_sw_version(device: FritzDevice) -> str:
     try:
@@ -42,107 +127,31 @@ def safe_call_action(device: FritzDevice, service: str, action: str) -> dict[str
     return result
 
 
+def _apply_builtin_sanitization(res: dict[tuple[str, str], dict]) -> None:
+    for svc_action, svc_data in res.items():
+        if svc_action in _SANITIZATION_BLACKLIST:
+            for field in _SANITIZATION_BLACKLIST[svc_action]:
+                if field in svc_data:
+                    svc_data[field] = _SANITIZED
+
+
+def _apply_custom_sanitization(res: dict[tuple[str, str], dict], sanitation: list[list]) -> None:
+    for entry in sanitation:
+        svc_action = (entry[0], entry[1])
+        if svc_action not in res:
+            continue
+        if len(entry) == 2:  # noqa: PLR2004
+            for field in res[svc_action]:
+                res[svc_action][field] = _SANITIZED
+        elif len(entry) == 3 and entry[2] in res[svc_action]:  # noqa: PLR2004
+            res[svc_action][entry[2]] = _SANITIZED
+
+
 def sanitize_results(
     res: dict[tuple[str, str], dict], sanitation: list[list]
 ) -> dict[tuple[str, str], dict[str, Any]]:
-    blacklist: dict[tuple[str, str], list[str]] = {
-        # (service, action): return_value
-        ("DeviceConfig1", "GetPersistentData"): ["NewPersistentData"],
-        ("DeviceConfig1", "X_AVM-DE_GetConfigFile"): ["NewConfigFile"],
-        ("DeviceInfo1", "GetDeviceLog"): ["NewDeviceLog"],
-        ("DeviceConfig1", "X_AVM-DE_GetSupportDataInfo"): ["NewX_AVM-DE_SupportDataID"],
-        ("DeviceInfo1", "GetInfo"): ["NewDeviceLog", "NewProvisioningCode", "NewSerialNumber"],
-        ("DeviceInfo1", "GetSecurityPort"): ["NewSecurityPort"],
-        ("Hosts1", "X_AVM-DE_GetHostListPath"): ["NewX_AVM-DE_HostListPath"],
-        ("Hosts1", "X_AVM-DE_GetMeshListPath"): ["NewX_AVM-DE_MeshListPath"],
-        ("LANConfigSecurity1", "X_AVM-DE_GetCurrentUser"): [
-            "NewX_AVM-DE_CurrentUserRights",
-            "NewX_AVM-DE_CurrentUsername",
-        ],
-        ("LANConfigSecurity1", "X_AVM-DE_GetUserList"): ["NewX_AVM-DE_UserList"],
-        ("LANEthernetInterfaceConfig1", "GetInfo"): ["NewMACAddress"],
-        ("LANHostConfigManagement1", "GetAddressRange"): ["NewMaxAddress", "NewMinAddress"],
-        ("LANHostConfigManagement1", "GetDNSServers"): ["NewDNSServers"],
-        ("LANHostConfigManagement1", "GetIPRoutersList"): ["NewIPRouters"],
-        ("LANHostConfigManagement1", "GetInfo"): [
-            "NewDNSServers",
-            "NewIPRouters",
-            "NewMaxAddress",
-            "NewMinAddress",
-        ],
-        ("ManagementServer1", "GetInfo"): ["NewUsername", "NewConnectionRequestURL"],
-        ("Time1", "GetInfo"): ["NewNTPServer1", "NewNTPServer2"],
-        ("WANCommonIFC1", "GetAddonInfos"): [
-            "NewDNSServer1",
-            "NewDNSServer2",
-            "NewVoipDNSServer1",
-            "NewVoipDNSServer2",
-        ],
-        ("WANIPConn1", "GetExternalIPAddress"): ["NewExternalIPAddress"],
-        ("WANIPConn1", "X_AVM_DE_GetDNSServer"): ["NewIPv4DNSServer1", "NewIPv4DNSServer2"],
-        ("WANIPConn1", "X_AVM_DE_GetExternalIPv6Address"): ["NewExternalIPv6Address"],
-        ("WANIPConn1", "X_AVM_DE_GetIPv6DNSServer"): ["NewIPv6DNSServer1", "NewIPv6DNSServer2"],
-        ("WANIPConn1", "X_AVM_DE_GetIPv6Prefix"): ["NewIPv6Prefix"],
-        ("WANIPConnection1", "GetExternalIPAddress"): ["NewExternalIPAddress"],
-        ("WANIPConnection1", "GetInfo"): ["NewDNSServers", "NewMACAddress", "NewExternalIPAddress"],
-        ("WANIPConnection1", "X_GetDNSServers"): ["NewDNSServers"],
-        ("WANPPPConnection1", "GetExternalIPAddress"): ["NewExternalIPAddress"],
-        ("WANPPPConnection1", "GetInfo"): [
-            "NewDNSServers",
-            "NewExternalIPAddress",
-            "NewMACAddress",
-            "NewUserName",
-        ],
-        ("WANPPPConnection1", "GetUserName"): ["NewUserName"],
-        ("WANPPPConnection1", "X_GetDNSServers"): ["NewDNSServers"],
-        **{
-            (f"WLANConfiguration{i}", action): fields
-            for i in range(1, 5)
-            for action, fields in [
-                ("GetBSSID", ["NewBSSID"]),
-                ("GetInfo", ["NewBSSID", "NewSSID"]),
-                ("GetSSID", ["NewSSID"]),
-                ("GetSecurityKeys", ["NewKeyPassphrase", "NewPreSharedKey", "NewWEPKey0", "NewWEPKey1", "NewWEPKey2", "NewWEPKey3"]),
-                ("X_AVM-DE_GetWLANDeviceListPath", ["NewX_AVM-DE_WLANDeviceListPath"]),
-                ("X_AVM-DE_GetWLANHybridMode", ["NewBSSID", "NewSSID"]),
-            ]
-        },
-        ("X_AVM-DE_AppSetup1", "GetAppRemoteInfo"): [
-            "NewExternalIPAddress",
-            "NewExternalIPv6Address",
-            "NewIPAddress",
-            "NewMyFritzDynDNSName",
-            "NewRemoteAccessDDNSDomain",
-        ],
-        ("X_AVM-DE_Dect1", "GetDectListPath"): ["NewDectListPath"],
-        ("X_AVM-DE_Filelinks1", "GetFilelinkListPath"): ["NewFilelinkListPath"],
-        ("X_AVM-DE_MyFritz1", "GetInfo"): ["NewDynDNSName", "NewPort"],
-        ("X_AVM-DE_OnTel1", "GetCallBarringList"): ["NewPhonebookURL"],
-        ("X_AVM-DE_OnTel1", "GetCallList"): ["NewCallListURL"],
-        ("X_AVM-DE_OnTel1", "GetDECTHandsetList"): ["NewDectIDList"],
-        ("X_AVM-DE_OnTel1", "GetDeflections"): ["NewDeflectionList"],
-        ("X_AVM-DE_RemoteAccess1", "GetDDNSInfo"): ["NewDomain", "NewUpdateURL", "NewUsername"],
-        ("X_AVM-DE_RemoteAccess1", "GetInfo"): ["NewPort", "NewUsername"],
-        ("X_AVM-DE_Storage1", "GetUserInfo"): ["NewUsername"],
-        ("X_AVM-DE_TAM1", "GetList"): ["NewTAMList"],
-        ("X_VoIP1", "X_AVM-DE_GetClients"): ["NewX_AVM-DE_ClientList"],
-        ("X_VoIP1", "X_AVM-DE_GetNumbers"): ["NewNumberList"],
-    }
-
-    for svc_action, svc_data in res.items():
-        if svc_action in blacklist:
-            for field in blacklist[svc_action]:
-                if field in svc_data:
-                    svc_data[field] = "<SANITIZED>"
-
-    for entry in sanitation:
-        if (entry[0], entry[1]) in res:
-            if len(entry) == 2:  # noqa: PLR2004
-                for field in res[(entry[0], entry[1])]:
-                    res[(entry[0], entry[1])][field] = "<SANITIZED>"
-            elif len(entry) == 3 and entry[2] in res[(entry[0], entry[1])]:  # noqa: PLR2004
-                res[(entry[0], entry[1])][entry[2]] = "<SANITIZED>"
-
+    _apply_builtin_sanitization(res)
+    _apply_custom_sanitization(res, sanitation)
     return res
 
 

--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -136,7 +136,7 @@ class FritzCapabilities:
             )
 
     def empty(self) -> bool:
-        return not any(cap.present for cap in list(self.capabilities.values()))
+        return not any(cap.present for cap in self.capabilities.values())
 
     def check_present(self, device: FritzDevice) -> None:
         for c in self.capabilities:
@@ -1014,7 +1014,7 @@ class HomeAutomation(FritzCapability):
         self.metrics["heater_reduced_valve_state"] = GaugeMetricFamily("fritz_ha_heater_reduced_valve_state", "Heater reduced valve state", labels=labels)
         self.metrics["heater_comfort_valve_state"] = GaugeMetricFamily("fritz_ha_heater_comfort_valve_state", "Heater comfort valve state", labels=labels)
 
-    def _ha_labels(
+    def _build_ha_labels(
         self,
         device: FritzDevice,
         ain: str,
@@ -1083,7 +1083,7 @@ class HomeAutomation(FritzCapability):
             device_name = ha_result["NewDeviceName"]
             manufacturer = ha_result["NewManufacturer"]
             productname = ha_result["NewProductName"]
-            labels = self._ha_labels(device, ain, device_id, device_name, manufacturer, productname)
+            labels = self._build_ha_labels(device, ain, device_id, device_name, manufacturer, productname)
 
             self.metrics["devicepresent"].add_metric(labels, self._DEVICE_PRESENT_MAP[ha_result["NewPresent"]])
             self._collect_multimeter(ha_result, labels)


### PR DESCRIPTION
## Summary

Addresses all 5 open SonarCloud issues:

| Severity | Rule | File | Fix |
|---|---|---|---|
| BLOCKER | S1845 | `fritzcapabilities.py:1009` | Rename `_ha_labels()` → `_build_ha_labels()` to avoid clash with `_HA_LABELS` ClassVar |
| CRITICAL | S3776 | `__main__.py:72` | Extract `_resolve_password()` and `_register_device()` from `main()` |
| CRITICAL | S3776 | `data_donation.py:45` | Extract `_apply_builtin_sanitization()` and `_apply_custom_sanitization()` from `sanitize_results()` |
| CRITICAL | S1192 | `data_donation.py:136` | Define `_SANITIZED = "<SANITIZED>"` constant; move `_SANITIZATION_BLACKLIST` to module level |
| MINOR | S7504 | `fritzcapabilities.py:138` | Remove unnecessary `list()` in `FritzCapabilities.empty()` |

## Test plan
- [x] `uv run pytest` — 103 tests, all passing
- [x] SonarCloud quality gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)