### PR TITLE
refactor: remove dead merge() and clarify FritzCollector capability ownership

### DIFF
--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -129,12 +129,6 @@ class FritzCapabilities:
     def items(self) -> collections.abc.ItemsView[str, FritzCapability]:
         return self.capabilities.items()
 
-    def merge(self, other_caps: FritzCapabilities) -> None:
-        for cap in self.capabilities:
-            self.capabilities[cap].present = (
-                self.capabilities[cap].present or other_caps.capabilities[cap].present
-            )
-
     def empty(self) -> bool:
         return not any(cap.present for cap in self.capabilities.values())
 

--- a/fritzexporter/fritzdevice.py
+++ b/fritzexporter/fritzdevice.py
@@ -128,13 +128,15 @@ class FritzCollector(Collector):
     def __init__(self) -> None:
         self.devices: list[FritzDevice] = []
         self.offline_devices: list[tuple[FritzCredentials, str, bool]] = []
-        self.capabilities: FritzCapabilities = FritzCapabilities()  # host_info=True??? FIXME
+        # One shared instance per capability class, used to drive the scrape loop and
+        # accumulate metrics across all devices. Distinct from per-device capabilities,
+        # which are the authority on what each device actually supports.
+        self._capability_instances: FritzCapabilities = FritzCapabilities()
         self._collect_lock = threading.RLock()
 
     def register(self, fritzdev: FritzDevice) -> None:
         self.devices.append(fritzdev)
         logger.debug("registered device %s (%s) to collector", fritzdev.host, fritzdev.model)
-        self.capabilities.merge(fritzdev.capabilities)
 
     def register_offline(
         self, creds: FritzCredentials, friendly_name: str, *, host_info: bool = False
@@ -182,7 +184,7 @@ class FritzCollector(Collector):
                 if mode_metric:
                     collected.append(mode_metric)
 
-            for name, capa in self.capabilities.items():
+            for name, capa in self._capability_instances.items():
                 collected.extend(list(capa.get_metrics(self.devices, name)))
 
             # Yield device availability metric for all known devices

--- a/tests/test_fritzdevice.py
+++ b/tests/test_fritzdevice.py
@@ -255,7 +255,7 @@ class TestFritzCollector:
             "HomeAutomation",
         ]
 
-        assert list(collector.capabilities.capabilities.keys()) == all_capas
+        assert list(collector._capability_instances.capabilities.keys()) == all_capas
 
     def test_should_register_device_to_collector(self, mock_fritzconnection: MagicMock, caplog):
         # Prepare


### PR DESCRIPTION
## Summary

Closes out the last architectural issue from the code review (#2 in the original list).

`FritzCollector` held a `FritzCapabilities` instance and called `merge()` on it every time a device was registered, ORing the `present` flags. The intent was to skip generating metrics for capabilities no device supports. However, `get_metrics()` never consults `self.present` on the collector's capability — it only checks `device.capabilities[name].present` per device inside the loop. The merged flags were accumulated and never read.

**Changes:**
- Remove `merge()` from `FritzCapabilities` (dead code)
- Remove the `merge()` call from `FritzCollector.register()`
- Rename `self.capabilities` → `self._capability_instances` to make the role explicit: a shared set of capability objects used to drive the scrape loop, intentionally distinct from per-device capabilities
- Drop the stale `FIXME` comment
- Update the one test that referenced the old name

Empty metric families (TYPE/HELP with no samples) produced for capabilities no device supports are valid Prometheus output and harmless.

## Test plan
- [x] `uv run pytest` — 103 tests, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)