### PR TITLE
Feature/per device connection timeout

### DIFF
--- a/fritzexporter/__main__.py
+++ b/fritzexporter/__main__.py
@@ -84,14 +84,18 @@ def _register_device(
     password = _resolve_password(dev)
     creds = FritzCredentials(dev.hostname, dev.username, password)
     try:
-        fritz_device = FritzDevice(creds, dev.name, host_info=dev.host_info)
+        fritz_device = FritzDevice(
+            creds, dev.name, host_info=dev.host_info, connection_timeout=dev.connection_timeout
+        )
     except (FritzConnectionException, FritzAuthorizationError, FritzDeviceHasNoCapabilitiesError):
         logger.exception(
             "Failed to initialize device %s (%s), it will be reported as down",
             dev.hostname,
             dev.name,
         )
-        fritzcollector.register_offline(creds, dev.name, host_info=dev.host_info)
+        fritzcollector.register_offline(
+            creds, dev.name, host_info=dev.host_info, connection_timeout=dev.connection_timeout
+        )
         return
 
     if args.donate_data == "donate":

--- a/fritzexporter/config/config.py
+++ b/fritzexporter/config/config.py
@@ -155,6 +155,7 @@ class DeviceConfig:
     password_file: str | None = field(default=None)
     name: str = ""
     host_info: bool = field(default=False, converter=converters.to_bool)
+    connection_timeout: int | None = field(default=None)
 
     @password.validator  # ty: ignore[unresolved-attribute]
     def check_password(self, _: attrs.Attribute, value: str | None) -> None:
@@ -179,6 +180,7 @@ class DeviceConfig:
         password_file = device.get("password_file")
         name = device.get("name", "")
         host_info = device.get("host_info", False)
+        connection_timeout = device.get("connection_timeout")
 
         return cls(
             hostname=hostname,
@@ -187,4 +189,5 @@ class DeviceConfig:
             password_file=password_file,
             name=name,
             host_info=host_info,
+            connection_timeout=connection_timeout,
         )

--- a/fritzexporter/fritzdevice.py
+++ b/fritzexporter/fritzdevice.py
@@ -30,7 +30,9 @@ class FritzCredentials(NamedTuple):
 
 
 class FritzDevice:
-    def __init__(self, creds: FritzCredentials, name: str, *, host_info: bool = False) -> None:
+    def __init__(
+        self, creds: FritzCredentials, name: str, *, host_info: bool = False, connection_timeout: int | None = None
+    ) -> None:
         self.host: str = creds.host
         self.serial: str = "n/a"
         self.model: str = "n/a"
@@ -46,7 +48,7 @@ class FritzDevice:
 
         try:
             self.fc: FritzConnection = FritzConnection(
-                address=creds.host, user=creds.user, password=creds.password
+                address=creds.host, user=creds.user, password=creds.password, timeout=connection_timeout
             )
         except FritzConnectionException:
             logger.exception("unable to connect to %s.", creds.host)
@@ -127,7 +129,7 @@ class FritzDevice:
 class FritzCollector(Collector):
     def __init__(self) -> None:
         self.devices: list[FritzDevice] = []
-        self.offline_devices: list[tuple[FritzCredentials, str, bool]] = []
+        self.offline_devices: list[tuple[FritzCredentials, str, bool, int | None]] = []
         # One shared instance per capability class, used to drive the scrape loop and
         # accumulate metrics across all devices. Distinct from per-device capabilities,
         # which are the authority on what each device actually supports.
@@ -139,16 +141,18 @@ class FritzCollector(Collector):
         logger.debug("registered device %s (%s) to collector", fritzdev.host, fritzdev.model)
 
     def register_offline(
-        self, creds: FritzCredentials, friendly_name: str, *, host_info: bool = False
+        self, creds: FritzCredentials, friendly_name: str, *, host_info: bool = False, connection_timeout: int | None = None
     ) -> None:
-        self.offline_devices.append((creds, friendly_name, host_info))
+        self.offline_devices.append((creds, friendly_name, host_info, connection_timeout))
         logger.debug("registered offline device %s (%s) to collector", creds.host, friendly_name)
 
     def _retry_offline_devices(self) -> None:
-        still_offline: list[tuple[FritzCredentials, str, bool]] = []
-        for creds, friendly_name, host_info in self.offline_devices:
+        still_offline: list[tuple[FritzCredentials, str, bool, int | None]] = []
+        for creds, friendly_name, host_info, connection_timeout in self.offline_devices:
             try:
-                fritz_device = FritzDevice(creds, friendly_name, host_info=host_info)
+                fritz_device = FritzDevice(
+                    creds, friendly_name, host_info=host_info, connection_timeout=connection_timeout
+                )
                 logger.info(
                     "Device %s (%s) is back online, registering to collector.",
                     creds.host,
@@ -160,7 +164,7 @@ class FritzCollector(Collector):
                 FritzAuthorizationError,
                 FritzDeviceHasNoCapabilitiesError,
             ):
-                still_offline.append((creds, friendly_name, host_info))
+                still_offline.append((creds, friendly_name, host_info, connection_timeout))
         self.offline_devices = still_offline
 
     def collect(self) -> collections.abc.Iterable[CounterMetricFamily | GaugeMetricFamily]:
@@ -197,7 +201,7 @@ class FritzCollector(Collector):
                 device_up.add_metric(
                     [dev.serial, dev.friendly_name], 1.0 if dev.available else 0.0
                 )
-            for _creds, friendly_name, _host_info in self.offline_devices:
+            for _creds, friendly_name, _host_info, _timeout in self.offline_devices:
                 device_up.add_metric(["n/a", friendly_name], 0.0)
             yield device_up
 

--- a/tests/conffiles/config_with_timeout.yaml
+++ b/tests/conffiles/config_with_timeout.yaml
@@ -1,0 +1,13 @@
+# Config with connection_timeout set on one device, absent on the other
+exporter_port: 9787
+listen_address: 127.0.0.1
+devices:
+  - name: Fritz!Box 7590 Router
+    hostname: fritz.box
+    username: prometheus1
+    password: prometheus2
+    connection_timeout: 10
+  - name: Repeater Wohnzimmer
+    hostname: repeater-Wohnzimmer
+    username: prometheus3
+    password: prometheus4

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -215,3 +215,19 @@ class TestConfigEdgeCases:
             )
         except FritzPasswordFileDoesNotExistError as e:
             assert "Password file does not exist" in str(e)
+
+    def test_connection_timeout_parsed_from_config(self):
+        testfile = "tests/conffiles/config_with_timeout.yaml"
+
+        config = get_config(testfile)
+
+        assert config.devices[0].connection_timeout == 10
+        assert config.devices[1].connection_timeout is None
+
+    def test_connection_timeout_defaults_to_none(self):
+        testfile = "tests/conffiles/validconfig.yaml"
+
+        config = get_config(testfile)
+
+        for dev in config.devices:
+            assert dev.connection_timeout is None

--- a/tests/test_fritzdevice.py
+++ b/tests/test_fritzdevice.py
@@ -127,7 +127,7 @@ class TestFritzDevice:
 
         assert mock_fritzconnection.call_count == 1
         assert mock_fritzconnection.call_args == call(
-            address="somehost", user="someuser", password="password"
+            address="somehost", user="someuser", password="password", timeout=None
         )
 
     def test_should_complain_about_password(self, mock_fritzconnection: MagicMock, caplog):
@@ -223,6 +223,37 @@ class TestFritzDevice:
         assert "battery_level" not in device_data
         assert "battery_low" not in device_data
 
+    def test_connection_timeout_passed_to_fritzconnection(self, mock_fritzconnection: MagicMock, caplog):
+        # Prepare
+        fc = mock_fritzconnection.return_value
+        fc.call_action.side_effect = call_action_mock
+        fc.services = create_fc_services(fc_services_devices["FritzBox 7590"])
+
+        # Act
+        _ = FritzDevice(
+            FritzCredentials("somehost", "someuser", "password"),
+            "FritzMock",
+            connection_timeout=10,
+        )
+
+        # Check: timeout must be forwarded to FritzConnection
+        assert mock_fritzconnection.call_args == call(
+            address="somehost", user="someuser", password="password", timeout=10
+        )
+
+    def test_connection_timeout_none_by_default(self, mock_fritzconnection: MagicMock, caplog):
+        # Prepare
+        fc = mock_fritzconnection.return_value
+        fc.call_action.side_effect = call_action_mock
+        fc.services = create_fc_services(fc_services_devices["FritzBox 7590"])
+
+        # Act
+        _ = FritzDevice(FritzCredentials("somehost", "someuser", "password"), "FritzMock")
+
+        # Check: no explicit timeout → None is passed (fritzconnection's own default)
+        assert mock_fritzconnection.call_args == call(
+            address="somehost", user="someuser", password="password", timeout=None
+        )
 
 
 @patch("fritzexporter.fritzdevice.FritzConnection")
@@ -532,6 +563,43 @@ class TestFritzCollector:
         assert reachable_round2[0].samples[0].value == 1.0
         assert reachable_round2[0].samples[0].labels["serial"] == "1234567890"
         assert reachable_round2[0].samples[0].labels["friendly_name"] == "FritzMock"
+        assert len(collector.devices) == 1
+        assert len(collector.offline_devices) == 0
+
+    def test_register_offline_preserves_connection_timeout(self, mock_fritzconnection: MagicMock):
+        # Prepare
+        collector = FritzCollector()
+        creds = FritzCredentials("offlinehost", "user", "pass")
+
+        # Act
+        collector.register_offline(creds, "OfflineDevice", connection_timeout=15)
+
+        # Check: timeout stored so that retry uses the same bound
+        assert len(collector.offline_devices) == 1
+        stored_timeout = collector.offline_devices[0][3]
+        assert stored_timeout == 15
+
+    def test_retry_offline_devices_uses_connection_timeout(self, mock_fritzconnection: MagicMock, caplog):
+        # Prepare: register device offline with a specific timeout
+        caplog.set_level(logging.DEBUG)
+
+        fc = mock_fritzconnection.return_value
+        fc.call_action.side_effect = FritzConnectionException("not reachable")
+        fc.services = create_fc_services(fc_services_devices["FritzBox 7590"])
+
+        collector = FritzCollector()
+        creds = FritzCredentials("somehost", "someuser", "password")
+        collector.register_offline(creds, "FritzMock", connection_timeout=7)
+
+        # Device comes back during retry
+        fc.call_action.side_effect = call_action_mock
+
+        list(collector.collect())
+
+        # Check: FritzConnection was called with the stored timeout during the retry
+        assert mock_fritzconnection.call_args == call(
+            address="somehost", user="someuser", password="password", timeout=7
+        )
         assert len(collector.devices) == 1
         assert len(collector.offline_devices) == 0
 


### PR DESCRIPTION
## Problem

`FritzConnection()` has no default timeout, so a single unreachable
device blocks the exporter startup indefinitely. In Fritz!Box mesh
setups, satellite devices (repeaters) can be temporarily offline while
the main router and other devices are fully functional. Today the only
workaround is to remove offline devices from the config, restart, and
add them back later.

## Solution

Add an optional `connection_timeout` (integer, seconds) per device.
When omitted, behaviour is unchanged (no timeout). When set, the value
is passed to `FritzConnection(timeout=...)`.

The timeout is also preserved through the offline-device retry path
(`FritzCollector._retry_offline_devices`), so reconnection attempts
after the initial failure use the same bound.

## Config example

```yaml
devices:
  - name: "Repeater"
    hostname: 192.168.178.60
    username: monitor
    password: "secret"
    connection_timeout: 10  # seconds; omit to keep current unlimited behaviour

Changes

- config/config.py: add connection_timeout: int | None field to DeviceConfig
- fritzdevice.py: accept and pass connection_timeout through FritzDevice and FritzCollector
- __main__.py: pass connection_timeout when registering devices (online and offline paths)
- tests/: fix existing FritzConnection call assertion; add tests for config parsing, timeout forwarding, and offline-device retry path

🤖 Created with Claude Code (https://claude.com/claude-code)