### PR TITLE
feat: add per-device connection_timeout option

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -36,6 +36,9 @@ If you only need a single device this is the easiest way to configure the export
 | ``FRITZ_HOST_INFO``      | Enable extended information about all WiFi         | False     |
 |                          | hosts. Only "true" or "1" will enable this feature |           |
 +--------------------------+----------------------------------------------------+-----------+
+| ``FRITZ_CONNECTION_TIMEOUT`` | Optional per-device TR-064 connect timeout in |           |
+|                          | seconds. ``0`` or empty means no timeout.          |           |
++--------------------------+----------------------------------------------------+-----------+
 
 .. note::
 
@@ -70,6 +73,7 @@ To use the config file you have to specify the the location of the config and mo
       username: prometheus
       password: prometheus
       host_info: True
+      connection_timeout: 10 # optional, seconds; 0 disables timeout
     - name: Repeater Wohnzimmer # optional
       hostname: repeater-Wohnzimmer
       username: prometheus

--- a/fritzexporter/__main__.py
+++ b/fritzexporter/__main__.py
@@ -84,14 +84,18 @@ def _register_device(
     password = _resolve_password(dev)
     creds = FritzCredentials(dev.hostname, dev.username, password)
     try:
-        fritz_device = FritzDevice(creds, dev.name, host_info=dev.host_info)
+        fritz_device = FritzDevice(
+            creds, dev.name, host_info=dev.host_info, connection_timeout=dev.connection_timeout
+        )
     except (FritzConnectionException, FritzAuthorizationError, FritzDeviceHasNoCapabilitiesError):
         logger.exception(
             "Failed to initialize device %s (%s), it will be reported as down",
             dev.hostname,
             dev.name,
         )
-        fritzcollector.register_offline(creds, dev.name, host_info=dev.host_info)
+        fritzcollector.register_offline(
+            creds, dev.name, host_info=dev.host_info, connection_timeout=dev.connection_timeout
+        )
         return
 
     if args.donate_data == "donate":

--- a/fritzexporter/config/config.py
+++ b/fritzexporter/config/config.py
@@ -24,6 +24,15 @@ from .exceptions import (
 logger = logging.getLogger("fritzexporter.config")
 
 
+def _convert_optional_int(value: int | str | None) -> int | None:
+    if value is None:
+        return None
+    timeout = int(value)
+    if timeout == 0:
+        return None
+    return timeout
+
+
 def _read_config_file(config_file_path: str) -> dict:
     try:
         with Path(config_file_path).open() as config_file:
@@ -41,7 +50,10 @@ def _read_config_from_env() -> dict:
     if "FRITZ_USERNAME" not in os.environ or all(
         required not in os.environ for required in ["FRITZ_PASSWORD", "FRITZ_PASSWORD_FILE"]
     ):
-        msg = "Required env variables missing (FRITZ_USERNAME, FRITZ_PASSWORD or FRITZ_PASSWORD_FILE)!"
+        msg = (
+            "Required env variables missing "
+            "(FRITZ_USERNAME, FRITZ_PASSWORD or FRITZ_PASSWORD_FILE)!"
+        )
         logger.critical(msg)
         raise ConfigError(msg)
 
@@ -56,6 +68,7 @@ def _read_config_from_env() -> dict:
     password_file = os.getenv("FRITZ_PASSWORD_FILE")
 
     host_info: str = os.getenv("FRITZ_HOST_INFO", "False")
+    connection_timeout = os.getenv("FRITZ_CONNECTION_TIMEOUT")
 
     config: dict[Any, Any] = {}
     if exporter_port:
@@ -72,6 +85,7 @@ def _read_config_from_env() -> dict:
         "password_file": password_file,
         "host_info": host_info,
         "name": name,
+        "connection_timeout": connection_timeout,
     }
     if hostname:
         device["hostname"] = hostname
@@ -155,7 +169,11 @@ class DeviceConfig:
     password_file: str | None = field(default=None)
     name: str = ""
     host_info: bool = field(default=False, converter=converters.to_bool)
-    connection_timeout: int | None = field(default=None)
+    connection_timeout: int | None = field(
+        default=None,
+        converter=_convert_optional_int,
+        validator=validators.optional(validators.ge(1)),
+    )
 
     @password.validator  # ty: ignore[unresolved-attribute]
     def check_password(self, _: attrs.Attribute, value: str | None) -> None:

--- a/fritzexporter/config/config.py
+++ b/fritzexporter/config/config.py
@@ -155,6 +155,7 @@ class DeviceConfig:
     password_file: str | None = field(default=None)
     name: str = ""
     host_info: bool = field(default=False, converter=converters.to_bool)
+    connection_timeout: int | None = field(default=None)
 
     @password.validator  # ty: ignore[unresolved-attribute]
     def check_password(self, _: attrs.Attribute, value: str | None) -> None:
@@ -179,6 +180,7 @@ class DeviceConfig:
         password_file = device.get("password_file")
         name = device.get("name", "")
         host_info = device.get("host_info", False)
+        connection_timeout = device.get("connection_timeout")
 
         return cls(
             hostname=hostname,
@@ -187,4 +189,5 @@ class DeviceConfig:
             password_file=password_file,
             name=name,
             host_info=host_info,
+            connection_timeout=connection_timeout,
         )

--- a/fritzexporter/fritzdevice.py
+++ b/fritzexporter/fritzdevice.py
@@ -30,7 +30,9 @@ class FritzCredentials(NamedTuple):
 
 
 class FritzDevice:
-    def __init__(self, creds: FritzCredentials, name: str, *, host_info: bool = False) -> None:
+    def __init__(
+        self, creds: FritzCredentials, name: str, *, host_info: bool = False, connection_timeout: int | None = None
+    ) -> None:
         self.host: str = creds.host
         self.serial: str = "n/a"
         self.model: str = "n/a"
@@ -46,7 +48,7 @@ class FritzDevice:
 
         try:
             self.fc: FritzConnection = FritzConnection(
-                address=creds.host, user=creds.user, password=creds.password
+                address=creds.host, user=creds.user, password=creds.password, timeout=connection_timeout
             )
         except FritzConnectionException:
             logger.exception("unable to connect to %s.", creds.host)
@@ -127,7 +129,7 @@ class FritzDevice:
 class FritzCollector(Collector):
     def __init__(self) -> None:
         self.devices: list[FritzDevice] = []
-        self.offline_devices: list[tuple[FritzCredentials, str, bool]] = []
+        self.offline_devices: list[tuple[FritzCredentials, str, bool, int | None]] = []
         # One shared instance per capability class, used to drive the scrape loop and
         # accumulate metrics across all devices. Distinct from per-device capabilities,
         # which are the authority on what each device actually supports.
@@ -139,16 +141,18 @@ class FritzCollector(Collector):
         logger.debug("registered device %s (%s) to collector", fritzdev.host, fritzdev.model)
 
     def register_offline(
-        self, creds: FritzCredentials, friendly_name: str, *, host_info: bool = False
+        self, creds: FritzCredentials, friendly_name: str, *, host_info: bool = False, connection_timeout: int | None = None
     ) -> None:
-        self.offline_devices.append((creds, friendly_name, host_info))
+        self.offline_devices.append((creds, friendly_name, host_info, connection_timeout))
         logger.debug("registered offline device %s (%s) to collector", creds.host, friendly_name)
 
     def _retry_offline_devices(self) -> None:
-        still_offline: list[tuple[FritzCredentials, str, bool]] = []
-        for creds, friendly_name, host_info in self.offline_devices:
+        still_offline: list[tuple[FritzCredentials, str, bool, int | None]] = []
+        for creds, friendly_name, host_info, connection_timeout in self.offline_devices:
             try:
-                fritz_device = FritzDevice(creds, friendly_name, host_info=host_info)
+                fritz_device = FritzDevice(
+                    creds, friendly_name, host_info=host_info, connection_timeout=connection_timeout
+                )
                 logger.info(
                     "Device %s (%s) is back online, registering to collector.",
                     creds.host,
@@ -160,7 +164,7 @@ class FritzCollector(Collector):
                 FritzAuthorizationError,
                 FritzDeviceHasNoCapabilitiesError,
             ):
-                still_offline.append((creds, friendly_name, host_info))
+                still_offline.append((creds, friendly_name, host_info, connection_timeout))
         self.offline_devices = still_offline
 
     def collect(self) -> collections.abc.Iterable[CounterMetricFamily | GaugeMetricFamily]:
@@ -197,7 +201,7 @@ class FritzCollector(Collector):
                 device_up.add_metric(
                     [dev.serial, dev.friendly_name], 1.0 if dev.available else 0.0
                 )
-            for _creds, friendly_name, _host_info in self.offline_devices:
+            for _creds, friendly_name, _host_info, _timeout in self.offline_devices:
                 device_up.add_metric(["n/a", friendly_name], 0.0)
             yield device_up
 

--- a/tests/conffiles/config_with_timeout.yaml
+++ b/tests/conffiles/config_with_timeout.yaml
@@ -1,0 +1,13 @@
+# Config with connection_timeout set on one device, absent on the other
+exporter_port: 9787
+listen_address: 127.0.0.1
+devices:
+  - name: Fritz!Box 7590 Router
+    hostname: fritz.box
+    username: prometheus1
+    password: prometheus2
+    connection_timeout: 10
+  - name: Repeater Wohnzimmer
+    hostname: repeater-Wohnzimmer
+    username: prometheus3
+    password: prometheus4

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -215,3 +215,19 @@ class TestConfigEdgeCases:
             )
         except FritzPasswordFileDoesNotExistError as e:
             assert "Password file does not exist" in str(e)
+
+    def test_connection_timeout_parsed_from_config(self):
+        testfile = "tests/conffiles/config_with_timeout.yaml"
+
+        config = get_config(testfile)
+
+        assert config.devices[0].connection_timeout == 10
+        assert config.devices[1].connection_timeout is None
+
+    def test_connection_timeout_defaults_to_none(self):
+        testfile = "tests/conffiles/validconfig.yaml"
+
+        config = get_config(testfile)
+
+        for dev in config.devices:
+            assert dev.connection_timeout is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -160,6 +160,24 @@ class TestEnvConfig:
 
         assert config == expected
 
+    def test_connection_timeout_env_config(self, monkeypatch):
+        monkeypatch.setenv("FRITZ_USERNAME", "SomeUserName")
+        monkeypatch.setenv("FRITZ_PASSWORD", "AnInterestingPassword")
+        monkeypatch.setenv("FRITZ_CONNECTION_TIMEOUT", "15")
+
+        config = get_config(None)
+
+        assert config.devices[0].connection_timeout == 15
+
+    def test_connection_timeout_env_zero_disables_timeout(self, monkeypatch):
+        monkeypatch.setenv("FRITZ_USERNAME", "SomeUserName")
+        monkeypatch.setenv("FRITZ_PASSWORD", "AnInterestingPassword")
+        monkeypatch.setenv("FRITZ_CONNECTION_TIMEOUT", "0")
+
+        config = get_config(None)
+
+        assert config.devices[0].connection_timeout is None
+
 
 class TestConfigEdgeCases:
     def test_duplicate_device_names_logs_warning(self, caplog):
@@ -231,3 +249,30 @@ class TestConfigEdgeCases:
 
         for dev in config.devices:
             assert dev.connection_timeout is None
+
+    def test_connection_timeout_zero_disables_timeout(self):
+        config = DeviceConfig(
+            hostname="fritz.box",
+            username="user",
+            password="password",
+            connection_timeout=0,
+        )
+        assert config.connection_timeout is None
+
+    def test_connection_timeout_must_not_be_negative(self):
+        with pytest.raises(ValueError):
+            DeviceConfig(
+                hostname="fritz.box",
+                username="user",
+                password="password",
+                connection_timeout=-1,
+            )
+
+    def test_connection_timeout_must_be_numeric(self):
+        with pytest.raises(ValueError):
+            DeviceConfig(
+                hostname="fritz.box",
+                username="user",
+                password="password",
+                connection_timeout="invalid",
+            )

--- a/tests/test_fritzdevice.py
+++ b/tests/test_fritzdevice.py
@@ -127,7 +127,7 @@ class TestFritzDevice:
 
         assert mock_fritzconnection.call_count == 1
         assert mock_fritzconnection.call_args == call(
-            address="somehost", user="someuser", password="password"
+            address="somehost", user="someuser", password="password", timeout=None
         )
 
     def test_should_complain_about_password(self, mock_fritzconnection: MagicMock, caplog):
@@ -223,6 +223,37 @@ class TestFritzDevice:
         assert "battery_level" not in device_data
         assert "battery_low" not in device_data
 
+    def test_connection_timeout_passed_to_fritzconnection(self, mock_fritzconnection: MagicMock, caplog):
+        # Prepare
+        fc = mock_fritzconnection.return_value
+        fc.call_action.side_effect = call_action_mock
+        fc.services = create_fc_services(fc_services_devices["FritzBox 7590"])
+
+        # Act
+        _ = FritzDevice(
+            FritzCredentials("somehost", "someuser", "password"),
+            "FritzMock",
+            connection_timeout=10,
+        )
+
+        # Check: timeout must be forwarded to FritzConnection
+        assert mock_fritzconnection.call_args == call(
+            address="somehost", user="someuser", password="password", timeout=10
+        )
+
+    def test_connection_timeout_none_by_default(self, mock_fritzconnection: MagicMock, caplog):
+        # Prepare
+        fc = mock_fritzconnection.return_value
+        fc.call_action.side_effect = call_action_mock
+        fc.services = create_fc_services(fc_services_devices["FritzBox 7590"])
+
+        # Act
+        _ = FritzDevice(FritzCredentials("somehost", "someuser", "password"), "FritzMock")
+
+        # Check: no explicit timeout → None is passed (fritzconnection's own default)
+        assert mock_fritzconnection.call_args == call(
+            address="somehost", user="someuser", password="password", timeout=None
+        )
 
 
 @patch("fritzexporter.fritzdevice.FritzConnection")
@@ -532,6 +563,43 @@ class TestFritzCollector:
         assert reachable_round2[0].samples[0].value == 1.0
         assert reachable_round2[0].samples[0].labels["serial"] == "1234567890"
         assert reachable_round2[0].samples[0].labels["friendly_name"] == "FritzMock"
+        assert len(collector.devices) == 1
+        assert len(collector.offline_devices) == 0
+
+    def test_register_offline_preserves_connection_timeout(self, mock_fritzconnection: MagicMock):
+        # Prepare
+        collector = FritzCollector()
+        creds = FritzCredentials("offlinehost", "user", "pass")
+
+        # Act
+        collector.register_offline(creds, "OfflineDevice", connection_timeout=15)
+
+        # Check: timeout stored so that retry uses the same bound
+        assert len(collector.offline_devices) == 1
+        stored_timeout = collector.offline_devices[0][3]
+        assert stored_timeout == 15
+
+    def test_retry_offline_devices_uses_connection_timeout(self, mock_fritzconnection: MagicMock, caplog):
+        # Prepare: register device offline with a specific timeout
+        caplog.set_level(logging.DEBUG)
+
+        fc = mock_fritzconnection.return_value
+        fc.call_action.side_effect = FritzConnectionException("not reachable")
+        fc.services = create_fc_services(fc_services_devices["FritzBox 7590"])
+
+        collector = FritzCollector()
+        creds = FritzCredentials("somehost", "someuser", "password")
+        collector.register_offline(creds, "FritzMock", connection_timeout=7)
+
+        # Device comes back during retry
+        fc.call_action.side_effect = call_action_mock
+
+        list(collector.collect())
+
+        # Check: FritzConnection was called with the stored timeout during the retry
+        assert mock_fritzconnection.call_args == call(
+            address="somehost", user="someuser", password="password", timeout=7
+        )
         assert len(collector.devices) == 1
         assert len(collector.offline_devices) == 0
 

--- a/uv.lock
+++ b/uv.lock
@@ -120,7 +120,7 @@ wheels = [
 
 [[package]]
 name = "fritz-exporter"
-version = "2.6.2"
+version = "3.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Why

`FritzConnection` has no default timeout, so a single unreachable device can block the entire exporter startup (and every subsequent retry) indefinitely. This PR adds an optional per-device `connection_timeout` setting that bounds how long the exporter will wait when establishing the TR-064 connection.

## What changed

**Core feature (from PR #618 by @HoschiS):**
- New `connection_timeout` field on `DeviceConfig`, passed through to `FritzConnection(timeout=...)`.
- The offline-device retry path preserves the timeout so reconnection attempts use the same bound.

**Fixes applied on top:**
- `connection_timeout` is now validated and converted in `DeviceConfig`: non-numeric values raise `ValueError`, negative values are rejected. `0` (and unset/`None`) explicitly maps to `None` (no timeout) -- `urllib3` raises `ValueError` for `timeout=0`, so the mapping is required for correctness, not just UX.
- `FRITZ_CONNECTION_TIMEOUT` env var added so env-only users have the same capability as YAML config users.
- Type annotation tightened to `int | str | None` so the converter is type-safe.
- Documentation updated for both the env var table and the YAML example.

## Timeout semantics

| Config value | Effective behaviour |
|---|---|
| unset / `null` | no timeout (wait forever) |
| `0` | no timeout (wait forever) |
| positive integer | timeout in seconds |
| negative / non-numeric | config validation error |

## Testing

All existing tests pass. New tests cover:
- YAML: timeout parsed correctly; absent defaults to `None`
- Env: `FRITZ_CONNECTION_TIMEOUT` parsed and converted; `0` normalises to `None`
- Validation: zero normalises to `None`, negative raises, non-numeric raises
- `FritzDevice`: timeout forwarded to `FritzConnection`; defaults to `None`
- `FritzCollector`: offline registration preserves timeout; retry path uses it