### PR TITLE
fix: harden security review follow-ups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,9 @@ Key configuration (see `pyproject.toml` `[tool.ruff]`):
 - **Ignored rules**: `E203`, `COM812`, `ISC001`, `ANN204`
 - Docstring style convention: **Google** (`[tool.ruff.lint.pydocstyle] convention = "google"`)
 - Use `# noqa: <CODE>` to suppress a specific rule where absolutely necessary; avoid blanket `# noqa`.
+- **Follow the boy scout rule.** Do not fix lint in unrelated code. If you are already touching a line or block, clean up lint issues there so you leave it cleaner than you found it.
+- **Adhere to the ruff rules in production code.** Treat `pyproject.toml` as the source of truth for exact lint boundaries, and keep `fritzexporter/` free of new `E501` violations.
+- **Tests and docs stay more flexible.** They are excluded from ruff, but should still remain reasonably readable.
 
 ---
 

--- a/fritzexporter/__main__.py
+++ b/fritzexporter/__main__.py
@@ -72,7 +72,7 @@ def parse_cmdline() -> argparse.Namespace:
 def _resolve_password(dev: DeviceConfig) -> str:
     if dev.password_file is not None:
         password = Path(dev.password_file).read_text().strip()
-        logger.info("Using password from password file %s", dev.password_file)
+        logger.debug("Using password from password file %s", dev.password_file)
     else:
         password = dev.password if dev.password is not None else ""
     return password

--- a/fritzexporter/data_donation.py
+++ b/fritzexporter/data_donation.py
@@ -77,7 +77,17 @@ _SANITIZATION_BLACKLIST: dict[tuple[str, str], list[str]] = {
             ("GetBSSID", ["NewBSSID"]),
             ("GetInfo", ["NewBSSID", "NewSSID"]),
             ("GetSSID", ["NewSSID"]),
-            ("GetSecurityKeys", ["NewKeyPassphrase", "NewPreSharedKey", "NewWEPKey0", "NewWEPKey1", "NewWEPKey2", "NewWEPKey3"]),
+            (
+                "GetSecurityKeys",
+                [
+                    "NewKeyPassphrase",
+                    "NewPreSharedKey",
+                    "NewWEPKey0",
+                    "NewWEPKey1",
+                    "NewWEPKey2",
+                    "NewWEPKey3",
+                ],
+            ),
             ("X_AVM-DE_GetWLANDeviceListPath", ["NewX_AVM-DE_WLANDeviceListPath"]),
             ("X_AVM-DE_GetWLANHybridMode", ["NewBSSID", "NewSSID"]),
         ]
@@ -224,7 +234,10 @@ def donate_data(
     if upload:
         upload_data(basedata)
     else:
-        print(f"---------------- Donation data for device {model} ---------------------")  # noqa: T201
+        print(
+            f"---------------- Donation data for device {model} "
+            "---------------------"
+        )  # noqa: T201
         print(json.dumps(basedata, indent=2))  # noqa: T201
         print("----------------- END ------------------")  # noqa: T201
         print()  # noqa: T201

--- a/fritzexporter/data_donation.py
+++ b/fritzexporter/data_donation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import sys
 from typing import Any
 
 import requests
@@ -214,8 +215,7 @@ def donate_data(
             if action.startswith("Get") and not (
                 "ByIP" in action
                 or "ByIndex" in action
-                or action.startswith("GetSpecific")
-                or action.startswith("GetGeneric")
+                or action.startswith(("GetSpecific", "GetGeneric"))
             ):
                 res = safe_call_action(device, service, action)
                 action_results[(service, action)] = res
@@ -234,13 +234,12 @@ def donate_data(
     if upload:
         upload_data(basedata)
     else:
-        print(
+        sys.stdout.write(
             f"---------------- Donation data for device {model} "
-            "---------------------"
-        )  # noqa: T201
-        print(json.dumps(basedata, indent=2))  # noqa: T201
-        print("----------------- END ------------------")  # noqa: T201
-        print()  # noqa: T201
+            "---------------------\n"
+        )
+        sys.stdout.write(f"{json.dumps(basedata, indent=2)}\n")
+        sys.stdout.write("----------------- END ------------------\n\n")
 
 # Copyright 2019-2026 Patrick Dreker <patrick@dreker.de>
 #

--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -4,6 +4,8 @@ import collections
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Generator, Iterator
+from contextlib import suppress
+from ipaddress import IPv4Address
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from fritzconnection.core.exceptions import (  # type: ignore[import]
@@ -162,7 +164,7 @@ class DeviceInfo(FritzCapability):
             info_result["NewUpTime"],
         )
 
-    def _get_metric_values(self) -> Generator[CounterMetricFamily | GaugeMetricFamily, None, None]:
+    def _get_metric_values(self) -> Generator[CounterMetricFamily | GaugeMetricFamily]:
         yield self.metrics["uptime"]
 
 
@@ -834,10 +836,12 @@ class HostInfo(FritzCapability):
         self.requirements.append(("Hosts1", "X_AVM-DE_GetSpecificHostEntryByIP"))
 
     def _probe_specific_host_entry(self, device: FritzDevice, svc: str, action: str) -> None:
-        try:
-            device.fc.call_action(svc, action, arguments={"NewIPAddress": "0.0.0.0"})
-        except FritzLookUpError:
-            pass  # 714 NoSuchEntryInArray — action works, 0.0.0.0 not in host table
+        with suppress(FritzLookUpError):
+            device.fc.call_action(
+                svc,
+                action,
+                arguments={"NewIPAddress": str(IPv4Address(0))},
+            )
 
     def _probe_action(self, device: FritzDevice, svc: str, action: str) -> bool:
         try:
@@ -1044,23 +1048,15 @@ class HomeAutomation(FritzCapability):
         for key, metric_name, help_text in metric_definitions:
             self.metrics[key] = GaugeMetricFamily(metric_name, help_text, labels=labels)
 
-    def _build_ha_labels(
-        self,
-        device: FritzDevice,
-        ain: str,
-        device_id: str,
-        device_name: str,
-        manufacturer: str,
-        productname: str,
-    ) -> list[str]:
+    def _build_ha_labels(self, device: FritzDevice, ha_result: dict[str, Any]) -> list[str]:
         return [
             device.serial,
             device.friendly_name,
-            ain,
-            device_name,
-            device_id,
-            manufacturer,
-            productname,
+            ha_result["NewAIN"],
+            ha_result["NewDeviceName"],
+            str(ha_result["NewDeviceId"]),
+            ha_result["NewManufacturer"],
+            ha_result["NewProductName"],
         ]
 
     def _collect_multimeter(self, ha_result: dict[str, Any], labels: list[str]) -> None:
@@ -1169,18 +1165,7 @@ class HomeAutomation(FritzCapability):
                 break
 
             ain = ha_result["NewAIN"]
-            device_id = str(ha_result["NewDeviceId"])
-            device_name = ha_result["NewDeviceName"]
-            manufacturer = ha_result["NewManufacturer"]
-            productname = ha_result["NewProductName"]
-            labels = self._build_ha_labels(
-                device,
-                ain,
-                device_id,
-                device_name,
-                manufacturer,
-                productname,
-            )
+            labels = self._build_ha_labels(device, ha_result)
 
             self.metrics["devicepresent"].add_metric(
                 labels,

--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import collections
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Generator, Iterator
+from collections.abc import Generator, Iterator, ItemsView
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
@@ -127,7 +126,7 @@ class FritzCapabilities:
     def __getitem__(self, index: str) -> FritzCapability:
         return self.capabilities[index]
 
-    def items(self) -> collections.abc.ItemsView[str, FritzCapability]:
+    def items(self) -> ItemsView[str, FritzCapability]:
         return self.capabilities.items()
 
     def empty(self) -> bool:

--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -5,7 +5,6 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import Generator, Iterator
 from contextlib import suppress
-from ipaddress import IPv4Address
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from fritzconnection.core.exceptions import (  # type: ignore[import]
@@ -837,10 +836,12 @@ class HostInfo(FritzCapability):
 
     def _probe_specific_host_entry(self, device: FritzDevice, svc: str, action: str) -> None:
         with suppress(FritzLookUpError):
+            # Probe the action with a deliberately bogus IP address; we only care
+            # whether the call is accepted and returns the expected lookup error.
             device.fc.call_action(
                 svc,
                 action,
-                arguments={"NewIPAddress": str(IPv4Address(0))},
+                arguments={"NewIPAddress": "0.0.0.0"},  # noqa: S104
             )
 
     def _probe_action(self, device: FritzDevice, svc: str, action: str) -> bool:

--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -990,23 +990,59 @@ class HomeAutomation(FritzCapability):
 
     def create_metrics(self) -> None:
         labels = self._HA_LABELS
-        self.metrics["devicepresent"] = GaugeMetricFamily("fritz_ha_device_present", "Indicates that the device is present", labels=labels)
-        self.metrics["battery_level"] = GaugeMetricFamily("fritz_ha_battery_level_percent", "Battery level in percent", labels=labels)
-        self.metrics["battery_low"] = GaugeMetricFamily("fritz_ha_battery_low", "Indicates that the battery is low", labels=labels)
-        self.metrics["multimeter_power"] = GaugeMetricFamily("fritz_ha_multimeter_power_W", "Power in W", labels=labels)
-        self.metrics["multimeter_energy"] = GaugeMetricFamily("fritz_ha_multimeter_energy_Wh", "Energy in Wh", labels=labels)
-        self.metrics["temperature"] = GaugeMetricFamily("fritz_ha_temperature_C", "Temperature in °C", labels=labels)
-        self.metrics["temperature_offset"] = GaugeMetricFamily("fritz_ha_temperature_offset_C", "Temperature offset in °C", labels=labels)
-        self.metrics["switch_state"] = GaugeMetricFamily("fritz_ha_switch_state", "Switch state", labels=labels)
-        self.metrics["switch_mode"] = GaugeMetricFamily("fritz_ha_switch_mode", "Switch mode", labels=labels)
-        self.metrics["switch_lock"] = GaugeMetricFamily("fritz_ha_switch_lock", "Switch lock", labels=labels)
-        self.metrics["heater_temperature"] = GaugeMetricFamily("fritz_ha_heater_temperature_C", "Heater temperature in °C", labels=labels)
-        self.metrics["heater_set_temperature"] = GaugeMetricFamily("fritz_ha_heater_set_temperature_C", "Heater set temperature in °C", labels=labels)
-        self.metrics["heater_valve_set_state"] = GaugeMetricFamily("fritz_ha_heater_valve_set_state", "Heater valve set state", labels=labels)
-        self.metrics["heater_reduced_temperature"] = GaugeMetricFamily("fritz_ha_heater_reduced_temperature_C", "Heater reduced temperature in °C", labels=labels)
-        self.metrics["heater_comfort_temperature"] = GaugeMetricFamily("fritz_ha_heater_comfort_temperature_C", "Heater comfort temperature in °C", labels=labels)
-        self.metrics["heater_reduced_valve_state"] = GaugeMetricFamily("fritz_ha_heater_reduced_valve_state", "Heater reduced valve state", labels=labels)
-        self.metrics["heater_comfort_valve_state"] = GaugeMetricFamily("fritz_ha_heater_comfort_valve_state", "Heater comfort valve state", labels=labels)
+        metric_definitions: list[tuple[str, str, str]] = [
+            ("devicepresent", "fritz_ha_device_present", "Indicates that the device is present"),
+            ("battery_level", "fritz_ha_battery_level_percent", "Battery level in percent"),
+            ("battery_low", "fritz_ha_battery_low", "Indicates that the battery is low"),
+            ("multimeter_power", "fritz_ha_multimeter_power_W", "Power in W"),
+            ("multimeter_energy", "fritz_ha_multimeter_energy_Wh", "Energy in Wh"),
+            ("temperature", "fritz_ha_temperature_C", "Temperature in °C"),
+            (
+                "temperature_offset",
+                "fritz_ha_temperature_offset_C",
+                "Temperature offset in °C",
+            ),
+            ("switch_state", "fritz_ha_switch_state", "Switch state"),
+            ("switch_mode", "fritz_ha_switch_mode", "Switch mode"),
+            ("switch_lock", "fritz_ha_switch_lock", "Switch lock"),
+            (
+                "heater_temperature",
+                "fritz_ha_heater_temperature_C",
+                "Heater temperature in °C",
+            ),
+            (
+                "heater_set_temperature",
+                "fritz_ha_heater_set_temperature_C",
+                "Heater set temperature in °C",
+            ),
+            (
+                "heater_valve_set_state",
+                "fritz_ha_heater_valve_set_state",
+                "Heater valve set state",
+            ),
+            (
+                "heater_reduced_temperature",
+                "fritz_ha_heater_reduced_temperature_C",
+                "Heater reduced temperature in °C",
+            ),
+            (
+                "heater_comfort_temperature",
+                "fritz_ha_heater_comfort_temperature_C",
+                "Heater comfort temperature in °C",
+            ),
+            (
+                "heater_reduced_valve_state",
+                "fritz_ha_heater_reduced_valve_state",
+                "Heater reduced valve state",
+            ),
+            (
+                "heater_comfort_valve_state",
+                "fritz_ha_heater_comfort_valve_state",
+                "Heater comfort valve state",
+            ),
+        ]
+        for key, metric_name, help_text in metric_definitions:
+            self.metrics[key] = GaugeMetricFamily(metric_name, help_text, labels=labels)
 
     def _build_ha_labels(
         self,
@@ -1017,36 +1053,93 @@ class HomeAutomation(FritzCapability):
         manufacturer: str,
         productname: str,
     ) -> list[str]:
-        return [device.serial, device.friendly_name, ain, device_name, device_id, manufacturer, productname]
+        return [
+            device.serial,
+            device.friendly_name,
+            ain,
+            device_name,
+            device_id,
+            manufacturer,
+            productname,
+        ]
 
     def _collect_multimeter(self, ha_result: dict[str, Any], labels: list[str]) -> None:
-        if ha_result["NewMultimeterIsEnabled"] == "ENABLED" and ha_result["NewMultimeterIsValid"] == "VALID":
-            self.metrics["multimeter_power"].add_metric(labels, ha_result["NewMultimeterPower"] / 100.0)
+        if (
+            ha_result["NewMultimeterIsEnabled"] == "ENABLED"
+            and ha_result["NewMultimeterIsValid"] == "VALID"
+        ):
+            self.metrics["multimeter_power"].add_metric(
+                labels,
+                ha_result["NewMultimeterPower"] / 100.0,
+            )
             self.metrics["multimeter_energy"].add_metric(labels, ha_result["NewMultimeterEnergy"])
 
     def _collect_temperature(self, ha_result: dict[str, Any], labels: list[str]) -> None:
-        if ha_result["NewTemperatureIsEnabled"] == "ENABLED" and ha_result["NewTemperatureIsValid"] == "VALID":
-            self.metrics["temperature"].add_metric(labels, ha_result["NewTemperatureCelsius"] / 10.0)
-            self.metrics["temperature_offset"].add_metric(labels, ha_result["NewTemperatureOffset"] / 10.0)
+        if (
+            ha_result["NewTemperatureIsEnabled"] == "ENABLED"
+            and ha_result["NewTemperatureIsValid"] == "VALID"
+        ):
+            self.metrics["temperature"].add_metric(
+                labels,
+                ha_result["NewTemperatureCelsius"] / 10.0,
+            )
+            self.metrics["temperature_offset"].add_metric(
+                labels,
+                ha_result["NewTemperatureOffset"] / 10.0,
+            )
 
     def _collect_switch(self, ha_result: dict[str, Any], labels: list[str]) -> None:
-        if ha_result["NewSwitchIsEnabled"] == "ENABLED" and ha_result["NewSwitchIsValid"] == "VALID":
-            self.metrics["switch_state"].add_metric(labels, self._SWITCH_STATE_MAP[ha_result["NewSwitchState"]])
-            self.metrics["switch_mode"].add_metric(labels, self._SWITCH_MODE_MAP[ha_result["NewSwitchMode"]])
-            self.metrics["switch_lock"].add_metric(labels, 1 if ha_result["NewSwitchLock"] else 0)
+        if (
+            ha_result["NewSwitchIsEnabled"] == "ENABLED"
+            and ha_result["NewSwitchIsValid"] == "VALID"
+        ):
+            self.metrics["switch_state"].add_metric(
+                labels,
+                self._SWITCH_STATE_MAP[ha_result["NewSwitchState"]],
+            )
+            self.metrics["switch_mode"].add_metric(
+                labels,
+                self._SWITCH_MODE_MAP[ha_result["NewSwitchMode"]],
+            )
+            self.metrics["switch_lock"].add_metric(
+                labels,
+                1 if ha_result["NewSwitchLock"] else 0,
+            )
 
     def _collect_heater(self, ha_result: dict[str, Any], labels: list[str]) -> None:
         if ha_result["NewHkrIsEnabled"] == "ENABLED" and ha_result["NewHkrIsValid"] == "VALID":
-            self.metrics["heater_temperature"].add_metric(labels, ha_result["NewHkrIsTemperature"] / 10.0)
-            self.metrics["heater_set_temperature"].add_metric(labels, ha_result["NewHkrSetTemperature"] / 10.0)
-            self.metrics["heater_valve_set_state"].add_metric(labels, self._HKR_VALVE_MAP[ha_result["NewHkrSetVentilStatus"]])
-            self.metrics["heater_reduced_temperature"].add_metric(labels, ha_result["NewHkrReduceTemperature"] / 10.0)
-            self.metrics["heater_comfort_temperature"].add_metric(labels, ha_result["NewHkrComfortTemperature"] / 10.0)
-            self.metrics["heater_reduced_valve_state"].add_metric(labels, self._HKR_VALVE_MAP[ha_result["NewHkrReduceVentilStatus"]])
-            self.metrics["heater_comfort_valve_state"].add_metric(labels, self._HKR_VALVE_MAP[ha_result["NewHkrComfortVentilStatus"]])
+            self.metrics["heater_temperature"].add_metric(
+                labels,
+                ha_result["NewHkrIsTemperature"] / 10.0,
+            )
+            self.metrics["heater_set_temperature"].add_metric(
+                labels,
+                ha_result["NewHkrSetTemperature"] / 10.0,
+            )
+            self.metrics["heater_valve_set_state"].add_metric(
+                labels,
+                self._HKR_VALVE_MAP[ha_result["NewHkrSetVentilStatus"]],
+            )
+            self.metrics["heater_reduced_temperature"].add_metric(
+                labels,
+                ha_result["NewHkrReduceTemperature"] / 10.0,
+            )
+            self.metrics["heater_comfort_temperature"].add_metric(
+                labels,
+                ha_result["NewHkrComfortTemperature"] / 10.0,
+            )
+            self.metrics["heater_reduced_valve_state"].add_metric(
+                labels,
+                self._HKR_VALVE_MAP[ha_result["NewHkrReduceVentilStatus"]],
+            )
+            self.metrics["heater_comfort_valve_state"].add_metric(
+                labels,
+                self._HKR_VALVE_MAP[ha_result["NewHkrComfortVentilStatus"]],
+            )
 
     def _collect_battery(self, device: FritzDevice, ain: str, labels: list[str]) -> None:
-        # Battery data comes from the AHA HTTP API, not TR-064; "battery" XML element maps to "battery_level"
+        # Battery data comes from the AHA HTTP API, not TR-064.
+        # "battery" XML element maps to "battery_level".
         try:
             http_result = device.fc.call_http("getdeviceinfos", ain)
         except FritzHttpInterfaceError:
@@ -1058,7 +1151,10 @@ class HomeAutomation(FritzCapability):
         if "battery_level" in http_data:
             self.metrics["battery_level"].add_metric(labels, float(http_data["battery_level"]))
         if "battery_low" in http_data:
-            self.metrics["battery_low"].add_metric(labels, 1 if http_data["battery_low"] == "1" else 0)
+            self.metrics["battery_low"].add_metric(
+                labels,
+                1 if http_data["battery_low"] == "1" else 0,
+            )
 
     def _generate_metric_values(self, device: FritzDevice) -> None:
         index = 0
@@ -1077,9 +1173,19 @@ class HomeAutomation(FritzCapability):
             device_name = ha_result["NewDeviceName"]
             manufacturer = ha_result["NewManufacturer"]
             productname = ha_result["NewProductName"]
-            labels = self._build_ha_labels(device, ain, device_id, device_name, manufacturer, productname)
+            labels = self._build_ha_labels(
+                device,
+                ain,
+                device_id,
+                device_name,
+                manufacturer,
+                productname,
+            )
 
-            self.metrics["devicepresent"].add_metric(labels, self._DEVICE_PRESENT_MAP[ha_result["NewPresent"]])
+            self.metrics["devicepresent"].add_metric(
+                labels,
+                self._DEVICE_PRESENT_MAP[ha_result["NewPresent"]],
+            )
             self._collect_multimeter(ha_result, labels)
             self._collect_temperature(ha_result, labels)
             self._collect_switch(ha_result, labels)

--- a/fritzexporter/fritzdevice.py
+++ b/fritzexporter/fritzdevice.py
@@ -31,7 +31,12 @@ class FritzCredentials(NamedTuple):
 
 class FritzDevice:
     def __init__(
-        self, creds: FritzCredentials, name: str, *, host_info: bool = False, connection_timeout: int | None = None
+        self,
+        creds: FritzCredentials,
+        name: str,
+        *,
+        host_info: bool = False,
+        connection_timeout: int | None = None,
     ) -> None:
         self.host: str = creds.host
         self.serial: str = "n/a"
@@ -48,7 +53,10 @@ class FritzDevice:
 
         try:
             self.fc: FritzConnection = FritzConnection(
-                address=creds.host, user=creds.user, password=creds.password, timeout=connection_timeout
+                address=creds.host,
+                user=creds.user,
+                password=creds.password,
+                timeout=connection_timeout,
             )
         except FritzConnectionException:
             logger.exception("unable to connect to %s.", creds.host)
@@ -141,7 +149,12 @@ class FritzCollector(Collector):
         logger.debug("registered device %s (%s) to collector", fritzdev.host, fritzdev.model)
 
     def register_offline(
-        self, creds: FritzCredentials, friendly_name: str, *, host_info: bool = False, connection_timeout: int | None = None
+        self,
+        creds: FritzCredentials,
+        friendly_name: str,
+        *,
+        host_info: bool = False,
+        connection_timeout: int | None = None,
     ) -> None:
         self.offline_devices.append((creds, friendly_name, host_info, connection_timeout))
         logger.debug("registered offline device %s (%s) to collector", creds.host, friendly_name)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -180,6 +180,24 @@ class TestEnvConfig:
 
 
 class TestConfigEdgeCases:
+    def test_bind_all_interfaces_logs_warning_for_ipv6(self, caplog):
+        caplog.set_level(logging.WARNING)
+
+        ExporterConfig.from_config(
+            {
+                "listen_address": "::",
+                "devices": [
+                    {
+                        "hostname": "fritz.box",
+                        "username": "user",
+                        "password": "password",
+                    }
+                ],
+            }
+        )
+
+        assert "Binding to all interfaces" in caplog.text
+
     def test_duplicate_device_names_logs_warning(self, caplog):
         testfile = "tests/conffiles/namesnotunique.yaml"
         caplog.set_level(logging.WARNING)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -193,6 +193,8 @@ class Test_Main:
                 "fritzexporter",
                 "--config",
                 "tests/conffiles/password_file.yaml",
+                "--log-level",
+                "DEBUG",
             ],
         )
         monkeypatch.setenv("FRITZ_EXPORTER_UNDER_TEST", "true")
@@ -205,4 +207,8 @@ class Test_Main:
 
         main()
 
-        assert "Using password from password file" in caplog.text
+        assert any(
+            "Using password from password file" in record.message
+            and record.levelno == logging.DEBUG
+            for record in caplog.records
+        )


### PR DESCRIPTION
This change addresses two very minor security review follow-ups by reducing unnecessary log verbosity around password file handling and locking in the expected bind-to-all-interfaces warning behavior.

As this is more code hygiene, the is a bigger linting cleanup mixed in with mainly overly long lines being split up, which have been introduced by a recent refactor where Copilot conveniently forgot, that linting is not optional ;-) Also fixed 7 further linter messages, so the code now comes up clean in ruff.

No functional changes should have been introduced, all tests pass.

## What changed
- Lowered the password-file path log from INFO to DEBUG so routine logs do not expose filesystem details.
- Added a regression test that verifies the IPv6 all-interfaces listen address still emits the expected warning.
- Updated the password-file test to run at DEBUG level so it covers the revised log level.

## Notes
- The IPv6 warning code was already correct; the new test is there to prevent regressions.

## Validation
- pytest
- ruff check on the changed files