### PR TITLE
fix(release): correct uv.lock JSONPath for release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -18,7 +18,7 @@
                 {
                     "type": "toml",
                     "path": "uv.lock",
-                    "jsonpath": "$.package[?(@.name==\"fritz-exporter\")].version"
+                    "jsonpath": "$.package[?(@.name.value==\"fritz-exporter\")].version"
                 }
             ]
         }


### PR DESCRIPTION
release-please was not updating `uv.lock` because the configured TOML JSONPath filter did not match release-please's parsed TOML value shape.

This updates the `extra-files` entry in `release-please-config.json` to target the wrapped TOML value field so the `fritz-exporter` package version in `uv.lock` is updated in release PRs.

### Change
- `$.package[?(@.name=="fritz-exporter")].version`
+ `$.package[?(@.name.value=="fritz-exporter")].version`

This removes the `No entries modified` warning for `uv.lock` and keeps lockfile version bumps aligned with release-please updates.