### PR TITLE
feat: add additionalLabels support to ServiceMonitor

### DIFF
--- a/helm/fritz-exporter/templates/servicemonitor.yaml
+++ b/helm/fritz-exporter/templates/servicemonitor.yaml
@@ -8,6 +8,9 @@ metadata:
   {{- end }}
   labels:
     {{- include "fritz-exporter.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   endpoints:
     - port: {{ .Values.service.portName | quote }}

--- a/helm/fritz-exporter/values.yaml
+++ b/helm/fritz-exporter/values.yaml
@@ -43,6 +43,7 @@ serviceMonitor:
   scrapeTimeout: "30s"
   relabelings: ""
   metricRelabelings: ""
+  additionalLabels: {}
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
## Description
Adds support for `additionalLabels` in the ServiceMonitor Helm chart configuration. This allows users to inject custom labels when deploying with kube-prometheus-stack or similar label-based discovery mechanisms.

## Changes
- Added `additionalLabels: {}` field to `serviceMonitor` section in `values.yaml`
- Updated `templates/servicemonitor.yaml` to merge additional labels into ServiceMonitor metadata

## Usage
Users can now add labels in their `values.yaml`:
```yaml
serviceMonitor:
  enabled: true
  additionalLabels:
    release: kube-prometheus-stack
```

## Validation
- Helm chart lints successfully with no errors
- Chart passes all linting checks

Fixes #626