### PR TITLE
fix(collector): keep WAN-less devices available so mesh repeaters export metrics

### DIFF
--- a/fritzexporter/fritzdevice.py
+++ b/fritzexporter/fritzdevice.py
@@ -111,6 +111,15 @@ class FritzDevice:
             resp = self.fc.call_action("WANCommonInterfaceConfig", "GetCommonLinkProperties")
             link_status = resp.get("NewPhysicalLinkStatus")
             access_type = resp.get("NewWANAccessType") or ""
+        except (FritzServiceError, FritzActionError):
+            # Device simply has no WAN interface (e.g. a mesh repeater). That does
+            # NOT make it unavailable — skip the connection-mode metric but keep
+            # the device available so its other capabilities (uptime, WLAN, hosts)
+            # are still collected.
+            logger.debug(
+                "No WAN connection-mode info on %s (no WAN service); skipping metric.", self.host
+            )
+            return None
         except FritzConnectionException:
             logger.exception("Failed to retrieve connection mode info from %s", self.host)
             self.available = False

--- a/tests/test_fritzdevice.py
+++ b/tests/test_fritzdevice.py
@@ -667,11 +667,12 @@ class TestFritzCollector:
         metrics: list[Metric] = list(collector.collect())
 
         # Check: device stays reachable ...
-        reachable = [m for m in metrics if m.name == "fritz_device_reachable"]
-        assert reachable[0].samples[0].value == 1.0
+        reachable = next((m for m in metrics if m.name == "fritz_device_reachable"), None)
+        assert reachable is not None
+        assert reachable.samples and reachable.samples[0].value == 1.0
         # ... and its capability metrics are still collected (empty before the fix)
-        uptime = [m for m in metrics if m.name == "fritz_uptime_seconds"]
-        assert len(uptime[0].samples) == 1
+        uptime = next((m for m in metrics if m.name == "fritz_uptime_seconds"), None)
+        assert uptime is not None and len(uptime.samples) == 1
 
 
 @patch("fritzexporter.fritzdevice.FritzConnection")

--- a/tests/test_fritzdevice.py
+++ b/tests/test_fritzdevice.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 from fritzconnection.core.exceptions import (
+    FritzActionError,
     FritzAuthorizationError,
     FritzConnectionException,
     FritzServiceError,
@@ -633,6 +634,45 @@ class TestFritzCollector:
         metric_names = [m.name for m in metrics]
         assert "fritz_connection_mode" not in metric_names
 
+    def test_should_collect_capabilities_from_wanless_repeater(
+        self, mock_fritzconnection: MagicMock, caplog
+    ):
+        # Regression: a WAN-less mesh repeater must still export its capabilities
+        # (uptime, WLAN, ...) and report reachable=1. The WAN-based connection-mode
+        # probe failing with a missing-service error must not mark it unavailable.
+        # Prepare
+        caplog.set_level(logging.DEBUG)
+
+        fc = mock_fritzconnection.return_value
+        fc.call_action.side_effect = call_action_mock
+        fc.call_http.side_effect = call_http_mock
+        fc.services = create_fc_services(fc_services_devices["FritzRepeater 2400"])
+
+        collector = FritzCollector()
+        device = FritzDevice(
+            FritzCredentials("repeater", "someuser", "password"), "RepeaterMock", host_info=False
+        )
+        collector.register(device)
+
+        # A repeater exposes no WAN service: the connection-mode probe raises a
+        # missing-service error (as fritzconnection does for an absent service).
+        def no_wan_service(service, action, **kwargs):
+            if service == "WANCommonInterfaceConfig" and action == "GetCommonLinkProperties":
+                raise FritzServiceError("no such service")
+            return call_action_mock(service, action, **kwargs)
+
+        fc.call_action.side_effect = no_wan_service
+
+        # Act
+        metrics: list[Metric] = list(collector.collect())
+
+        # Check: device stays reachable ...
+        reachable = [m for m in metrics if m.name == "fritz_device_reachable"]
+        assert reachable[0].samples[0].value == 1.0
+        # ... and its capability metrics are still collected (empty before the fix)
+        uptime = [m for m in metrics if m.name == "fritz_uptime_seconds"]
+        assert len(uptime[0].samples) == 1
+
 
 @patch("fritzexporter.fritzdevice.FritzConnection")
 class TestGetConnectionMode:
@@ -714,6 +754,28 @@ class TestGetConnectionMode:
         # Check
         assert metric is not None
         assert metric.samples[0].value == 0
+
+    @pytest.mark.parametrize("exc", [FritzServiceError, FritzActionError])
+    def test_get_connection_mode_keeps_device_available_on_missing_wan(self, mock_fc: MagicMock, exc):
+        # A device without a WAN interface (e.g. a mesh repeater) reports no
+        # connection mode, but must NOT be marked unavailable — otherwise the
+        # collect loop would skip all its other capabilities every scrape.
+        # Prepare
+        device, fc = self._create_device(mock_fc)
+
+        def raise_missing_service(s, a, **kw):
+            if (s, a) == ("WANCommonInterfaceConfig", "GetCommonLinkProperties"):
+                raise exc("no WAN service on this device")
+            return call_action_mock(s, a, **kw)
+
+        fc.call_action.side_effect = raise_missing_service
+
+        # Act
+        metric = device.get_connection_mode()
+
+        # Check: no metric, but the device stays available
+        assert metric is None
+        assert device.available is True
 
     def test_get_connection_mode_returns_none_on_exception(self, mock_fc: MagicMock, caplog):
         # Prepare


### PR DESCRIPTION
## Problem
Mesh repeaters (and any WAN-less device) only ever export `fritz_device_reachable = 0`
and none of their other metrics — no uptime, WLAN, hosts, etc. — even though they are
fully reachable and the TR-064 API returns that data.

## Root cause
`FritzDevice.get_connection_mode()` probes `WANCommonInterfaceConfig` to emit the
`fritz_connection_mode` gauge. On a device without a WAN interface that call raises a
missing-service error (`FritzServiceError`, a subclass of `FritzConnectionException`),
which set the whole device to `available = False`. Since the collect loop gates every
capability on `device.available` (`fritzcapabilities.py`), all of the device's metrics
are then skipped — leaving only `fritz_device_reachable = 0`.

## Fix
Catch `FritzServiceError` / `FritzActionError` separately in `get_connection_mode()`:
skip only the connection-mode metric and keep the device `available`, so its other
capabilities are still collected. A genuine `FritzConnectionException` (real
connectivity failure) still marks the device unavailable as before.

## Testing
- New unit test: `get_connection_mode()` keeps `available = True` on a missing-WAN
  error (parametrized over `FritzServiceError` / `FritzActionError`).
- New regression test: a WAN-less repeater profile (`FritzRepeater 2400`) still emits
  `fritz_device_reachable = 1` and capability metrics (e.g. `fritz_uptime_seconds`).
- Full suite green (118 passed).

## PR checklist
- Docs/Dockerfile/Helm: no changes — this is a pure collection-logic bug fix with no
  new config option, CLI flag, metric, or dependency.

## Notes
- Data from Repeater models that are "unlocked" by this PR have been donated today (2026-06-15) via --donate-data. Donation IDs: cc649ed1-0ffb-4d8f-88c6-d39a81cc6808 (FRITZ!repeater 1200 AX) & b7d4917c-6de0-4aba-aa81-22cf5e9cc4fb (FRITZ!repeater 1200)
- Data from a FRITZ!Box 6490 Cable have been donated today with donation ID afa77d69-2ccc-4109-b571-44a064e65b2b