### PR TITLE
feat(capabilities): add opt-in per-client WiFi metrics (signal + speed)

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -13,32 +13,35 @@ Environment variable
 
 If you only need a single device this is the easiest way to configure the exporter.
 
-+--------------------------+----------------------------------------------------+-----------+
-| Env variable             | Description                                        | Default   |
-+=========================-+====================================================+===========+
-| ``FRITZ_NAME``           | User-friendly name for the device                  | Fritz!Box |
-+--------------------------+----------------------------------------------------+-----------+
-| ``FRITZ_HOSTNAME``       | Hostname of the device                             | fritz.box |
-+--------------------------+----------------------------------------------------+-----------+
-| ``FRITZ_USERNAME``       | Username to authenticate on the device             | none      |
-+--------------------------+----------------------------------------------------+-----------+
-| ``FRITZ_PASSWORD``       | Password to use for authentication                 | none      |
-+--------------------------+----------------------------------------------------+-----------+
-| ``FRITZ_PASSWORD_FILE``  | File to read the password from                     |           |
-+--------------------------+----------------------------------------------------+-----------+
-| ``FRITZ_LISTEN_ADDRESS`` | Address to listen on. Can be IPv4 or IPv6.         | 127.0.0.1 |
-+--------------------------+----------------------------------------------------+-----------+
-| ``FRITZ_PORT``           | Listening port for the exporter                    |      9787 |
-+--------------------------+----------------------------------------------------+-----------+
-| ``FRITZ_LOG_LEVEL``      | Application log level: ``DEBUG``, ``INFO``,        | INFO      |
-|                          | ``WARNING``, ``ERROR``, ``CRITICAL``               |           |
-+--------------------------+----------------------------------------------------+-----------+
-| ``FRITZ_HOST_INFO``      | Enable extended information about all WiFi         | False     |
-|                          | hosts. Only "true" or "1" will enable this feature |           |
-+--------------------------+----------------------------------------------------+-----------+
-| ``FRITZ_CONNECTION_TIMEOUT`` | Optional per-device TR-064 connect timeout in |           |
-|                          | seconds. ``0`` or empty means no timeout.          |           |
-+--------------------------+----------------------------------------------------+-----------+
++------------------------------+----------------------------------------------------+-----------+
+| Env variable                 | Description                                        | Default   |
++==============================+====================================================+===========+
+| ``FRITZ_NAME``               | User-friendly name for the device                  | Fritz!Box |
++------------------------------+----------------------------------------------------+-----------+
+| ``FRITZ_HOSTNAME``           | Hostname of the device                             | fritz.box |
++------------------------------+----------------------------------------------------+-----------+
+| ``FRITZ_USERNAME``           | Username to authenticate on the device             | none      |
++------------------------------+----------------------------------------------------+-----------+
+| ``FRITZ_PASSWORD``           | Password to use for authentication                 | none      |
++------------------------------+----------------------------------------------------+-----------+
+| ``FRITZ_PASSWORD_FILE``      | File to read the password from                     |           |
++------------------------------+----------------------------------------------------+-----------+
+| ``FRITZ_LISTEN_ADDRESS``     | Address to listen on. Can be IPv4 or IPv6.         | 127.0.0.1 |
++------------------------------+----------------------------------------------------+-----------+
+| ``FRITZ_PORT``               | Listening port for the exporter                    | 9787      |
++------------------------------+----------------------------------------------------+-----------+
+| ``FRITZ_LOG_LEVEL``          | Application log level: ``DEBUG``, ``INFO``,        | INFO      |
+|                              | ``WARNING``, ``ERROR``, ``CRITICAL``               |           |
++------------------------------+----------------------------------------------------+-----------+
+| ``FRITZ_HOST_INFO``          | Enable extended information about all WiFi         | False     |
+|                              | hosts. Only "true" or "1" will enable this feature |           |
++------------------------------+----------------------------------------------------+-----------+
+| ``FRITZ_WIFI_CLIENT_INFO``   | Enable per-client WiFi metrics (signal/speed).     | False     |
+|                              | Only "true" or "1" will enable this feature.       |           |
++------------------------------+----------------------------------------------------+-----------+
+| ``FRITZ_CONNECTION_TIMEOUT`` | Optional per-device TR-064 connect timeout in      |           |
+|                              | seconds. ``0`` or empty means no timeout.          |           |
++------------------------------+----------------------------------------------------+-----------+
 
 .. note::
 
@@ -73,6 +76,7 @@ To use the config file you have to specify the the location of the config and mo
       username: prometheus
       password: prometheus
       host_info: True
+      wifi_client_info: True # optional, per-client WiFi signal/speed (higher cardinality)
       connection_timeout: 10 # optional, seconds; 0 disables timeout
     - name: Repeater Wohnzimmer # optional
       hostname: repeater-Wohnzimmer
@@ -82,3 +86,7 @@ To use the config file you have to specify the the location of the config and mo
 .. note::
 
   Enabling ``FRITZ_HOST_INFO`` by setting it to ``true`` or ``1`` will collect extended information about every device known to your Fritz device, which can take a long time (20+ seconds). If you really want or need the extended stats, please make sure that your Prometheus scraping interval and timeouts are set accordingly.
+
+.. note::
+
+  Enabling ``FRITZ_WIFI_CLIENT_INFO`` (``true`` or ``1``) exposes per-station WiFi metrics (signal strength and negotiated speed) for every associated client, on the box and on mesh repeaters alike. This adds one time series per connected client, so it is disabled by default — enable it only if you want per-client visibility and are aware of the extra cardinality.

--- a/fritzexporter/__main__.py
+++ b/fritzexporter/__main__.py
@@ -85,7 +85,11 @@ def _register_device(
     creds = FritzCredentials(dev.hostname, dev.username, password)
     try:
         fritz_device = FritzDevice(
-            creds, dev.name, host_info=dev.host_info, connection_timeout=dev.connection_timeout
+            creds,
+            dev.name,
+            host_info=dev.host_info,
+            wifi_client_info=dev.wifi_client_info,
+            connection_timeout=dev.connection_timeout,
         )
     except (FritzConnectionException, FritzAuthorizationError, FritzDeviceHasNoCapabilitiesError):
         logger.exception(
@@ -94,7 +98,11 @@ def _register_device(
             dev.name,
         )
         fritzcollector.register_offline(
-            creds, dev.name, host_info=dev.host_info, connection_timeout=dev.connection_timeout
+            creds,
+            dev.name,
+            host_info=dev.host_info,
+            wifi_client_info=dev.wifi_client_info,
+            connection_timeout=dev.connection_timeout,
         )
         return
 

--- a/fritzexporter/config/config.py
+++ b/fritzexporter/config/config.py
@@ -68,6 +68,7 @@ def _read_config_from_env() -> dict:
     password_file = os.getenv("FRITZ_PASSWORD_FILE")
 
     host_info: str = os.getenv("FRITZ_HOST_INFO", "False")
+    wifi_client_info: str = os.getenv("FRITZ_WIFI_CLIENT_INFO", "False")
     connection_timeout = os.getenv("FRITZ_CONNECTION_TIMEOUT")
 
     config: dict[Any, Any] = {}
@@ -84,6 +85,7 @@ def _read_config_from_env() -> dict:
         "password": password,
         "password_file": password_file,
         "host_info": host_info,
+        "wifi_client_info": wifi_client_info,
         "name": name,
         "connection_timeout": connection_timeout,
     }
@@ -169,6 +171,7 @@ class DeviceConfig:
     password_file: str | None = field(default=None)
     name: str = ""
     host_info: bool = field(default=False, converter=converters.to_bool)
+    wifi_client_info: bool = field(default=False, converter=converters.to_bool)
     connection_timeout: int | None = field(
         default=None,
         converter=_convert_optional_int,
@@ -198,6 +201,7 @@ class DeviceConfig:
         password_file = device.get("password_file")
         name = device.get("name", "")
         host_info = device.get("host_info", False)
+        wifi_client_info = device.get("wifi_client_info", False)
         connection_timeout = device.get("connection_timeout")
 
         return cls(
@@ -207,5 +211,6 @@ class DeviceConfig:
             password_file=password_file,
             name=name,
             host_info=host_info,
+            wifi_client_info=wifi_client_info,
             connection_timeout=connection_timeout,
         )

--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -886,13 +886,38 @@ class WlanAssociatedDevices(FritzCapability):
             if not present:
                 continue
             service = f"WLANConfiguration{index + 1}"
-            assoc = device.fc.call_action(service, "GetTotalAssociations")
-            for client_index in range(assoc["NewTotalAssociations"]):
-                info = device.fc.call_action(
+            try:
+                assoc = device.fc.call_action(service, "GetTotalAssociations")
+                total = int(assoc.get("NewTotalAssociations", 0))
+            except (FritzServiceError, FritzActionError, FritzInternalError) as e:
+                logger.warning(
+                    "failed to read WiFi associations from %s on %s: %s",
                     service,
-                    "GetGenericAssociatedDeviceInfo",
-                    NewAssociatedDeviceIndex=client_index,
+                    device.host,
+                    str(e),
                 )
+                continue
+            for client_index in range(total):
+                try:
+                    info = device.fc.call_action(
+                        service,
+                        "GetGenericAssociatedDeviceInfo",
+                        NewAssociatedDeviceIndex=client_index,
+                    )
+                except (
+                    FritzArrayIndexError,
+                    FritzServiceError,
+                    FritzActionError,
+                    FritzInternalError,
+                ) as e:
+                    logger.debug(
+                        "failed to read associated device info for %s index %d on %s: %s",
+                        service,
+                        client_index,
+                        device.host,
+                        str(e),
+                    )
+                    break
                 labels = [
                     device.serial,
                     device.friendly_name,

--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -826,6 +826,90 @@ class WlanConfigurationInfo(FritzCapability):
         yield self.metrics["wlanpackets"]
 
 
+class WlanAssociatedDevices(FritzCapability):
+    """Per-station WiFi client metrics (signal strength + negotiated speed).
+
+    Opt-in via the device ``wifi_client_info`` flag: it emits one time series per
+    associated client (per-client cardinality), so it is disabled by default just
+    like ``host_info``. Works on any device with radios — the box and (with the
+    repeater availability fix) mesh repeaters alike.
+    """
+
+    WIFI_NAMES: ClassVar[list[str]] = ["2.4GHz", "5GHz", "Guest", "WLAN4"]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.wifi_present: list[bool] = [False] * len(self.WIFI_NAMES)
+
+    def check_capability(self, device: FritzDevice) -> None:
+        if not device.wifi_client_info:
+            self.present = False
+            return
+        for index in range(len(self.WIFI_NAMES)):
+            service = f"WLANConfiguration{index + 1}"
+            required = ("GetTotalAssociations", "GetGenericAssociatedDeviceInfo")
+            present = service in device.fc.services and all(
+                action in device.fc.services[service].actions for action in required
+            )
+            # Only GetTotalAssociations is safe to probe live; GetGenericAssociatedDeviceInfo
+            # needs an index and raises on a radio with no clients.
+            if present:
+                try:
+                    device.fc.call_action(service, "GetTotalAssociations")
+                except (FritzServiceError, FritzActionError, FritzInternalError) as e:
+                    logger.warning(
+                        "disabling metrics at service %s, action GetTotalAssociations - "
+                        "fritzconnection.call_action returned %s",
+                        service,
+                        str(e),
+                    )
+                    present = False
+            self.wifi_present[index] = present
+        self.present = any(self.wifi_present)
+
+    def create_metrics(self) -> None:
+        labels = ["serial", "friendly_name", "wifi_name", "client_mac", "client_ip"]
+        self.metrics["signal"] = GaugeMetricFamily(
+            "fritz_wifi_client_signal_strength",
+            "Signal strength of an associated WiFi client in percent",
+            labels=labels,
+        )
+        self.metrics["speed"] = GaugeMetricFamily(
+            "fritz_wifi_client_speed",
+            "Negotiated speed of an associated WiFi client in Mbit/s",
+            labels=labels,
+        )
+
+    def _generate_metric_values(self, device: FritzDevice) -> None:
+        device_cap = cast(WlanAssociatedDevices, device.capabilities[self.__class__.__name__])
+        for index, present in enumerate(device_cap.wifi_present):
+            if not present:
+                continue
+            service = f"WLANConfiguration{index + 1}"
+            assoc = device.fc.call_action(service, "GetTotalAssociations")
+            for client_index in range(assoc["NewTotalAssociations"]):
+                info = device.fc.call_action(
+                    service,
+                    "GetGenericAssociatedDeviceInfo",
+                    NewAssociatedDeviceIndex=client_index,
+                )
+                labels = [
+                    device.serial,
+                    device.friendly_name,
+                    self.WIFI_NAMES[index],
+                    info["NewAssociatedDeviceMACAddress"],
+                    info["NewAssociatedDeviceIPAddress"],
+                ]
+                self.metrics["signal"].add_metric(labels, info["NewX_AVM-DE_SignalStrength"])
+                self.metrics["speed"].add_metric(labels, info["NewX_AVM-DE_Speed"])
+
+    def _get_metric_values(
+        self,
+    ) -> Iterator[CounterMetricFamily | GaugeMetricFamily]:
+        yield self.metrics["signal"]
+        yield self.metrics["speed"]
+
+
 class HostInfo(FritzCapability):
     def __init__(self) -> None:
         super().__init__()

--- a/fritzexporter/fritzdevice.py
+++ b/fritzexporter/fritzdevice.py
@@ -36,6 +36,7 @@ class FritzDevice:
         name: str,
         *,
         host_info: bool = False,
+        wifi_client_info: bool = False,
         connection_timeout: int | None = None,
     ) -> None:
         self.host: str = creds.host
@@ -43,6 +44,7 @@ class FritzDevice:
         self.model: str = "n/a"
         self.friendly_name: str = name
         self.host_info: bool = host_info
+        self.wifi_client_info: bool = wifi_client_info
         self.available: bool = True
 
         if len(creds.password) > FRITZ_MAX_PASSWORD_LENGTH:
@@ -137,7 +139,7 @@ class FritzDevice:
 class FritzCollector(Collector):
     def __init__(self) -> None:
         self.devices: list[FritzDevice] = []
-        self.offline_devices: list[tuple[FritzCredentials, str, bool, int | None]] = []
+        self.offline_devices: list[tuple[FritzCredentials, str, bool, int | None, bool]] = []
         # One shared instance per capability class, used to drive the scrape loop and
         # accumulate metrics across all devices. Distinct from per-device capabilities,
         # which are the authority on what each device actually supports.
@@ -154,17 +156,30 @@ class FritzCollector(Collector):
         friendly_name: str,
         *,
         host_info: bool = False,
+        wifi_client_info: bool = False,
         connection_timeout: int | None = None,
     ) -> None:
-        self.offline_devices.append((creds, friendly_name, host_info, connection_timeout))
+        self.offline_devices.append(
+            (creds, friendly_name, host_info, connection_timeout, wifi_client_info)
+        )
         logger.debug("registered offline device %s (%s) to collector", creds.host, friendly_name)
 
     def _retry_offline_devices(self) -> None:
-        still_offline: list[tuple[FritzCredentials, str, bool, int | None]] = []
-        for creds, friendly_name, host_info, connection_timeout in self.offline_devices:
+        still_offline: list[tuple[FritzCredentials, str, bool, int | None, bool]] = []
+        for (
+            creds,
+            friendly_name,
+            host_info,
+            connection_timeout,
+            wifi_client_info,
+        ) in self.offline_devices:
             try:
                 fritz_device = FritzDevice(
-                    creds, friendly_name, host_info=host_info, connection_timeout=connection_timeout
+                    creds,
+                    friendly_name,
+                    host_info=host_info,
+                    wifi_client_info=wifi_client_info,
+                    connection_timeout=connection_timeout,
                 )
                 logger.info(
                     "Device %s (%s) is back online, registering to collector.",
@@ -177,7 +192,9 @@ class FritzCollector(Collector):
                 FritzAuthorizationError,
                 FritzDeviceHasNoCapabilitiesError,
             ):
-                still_offline.append((creds, friendly_name, host_info, connection_timeout))
+                still_offline.append(
+                    (creds, friendly_name, host_info, connection_timeout, wifi_client_info)
+                )
         self.offline_devices = still_offline
 
     def collect(self) -> collections.abc.Iterable[CounterMetricFamily | GaugeMetricFamily]:
@@ -214,7 +231,7 @@ class FritzCollector(Collector):
                 device_up.add_metric(
                     [dev.serial, dev.friendly_name], 1.0 if dev.available else 0.0
                 )
-            for _creds, friendly_name, _host_info, _timeout in self.offline_devices:
+            for _creds, friendly_name, _host_info, _timeout, _wifi in self.offline_devices:
                 device_up.add_metric(["n/a", friendly_name], 0.0)
             yield device_up
 

--- a/helm/fritz-exporter/values.yaml
+++ b/helm/fritz-exporter/values.yaml
@@ -12,6 +12,7 @@ config: {}
 #     username: prometheus
 #     password: prometheus
 #     host_info: True
+#     wifi_client_info: True # optional, per-client WiFi signal/speed (higher cardinality)
 #   - name: Repeater Wohnzimmer # optional
 #     hostname: repeater-Wohnzimmer
 #     username: prometheus

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -319,7 +319,6 @@ class TestWifiClientInfoConfig:
         # Env path: FRITZ_WIFI_CLIENT_INFO -> DeviceConfig
         monkeypatch.setenv("FRITZ_USERNAME", "user")
         monkeypatch.setenv("FRITZ_PASSWORD", "password")
-        monkeypatch.setenv("FRITZ_WIFI_CLIENT_INFO", "True")
-
+        monkeypatch.setenv("FRITZ_WIFI_CLIENT_INFO", "true")
         config = get_config(None)
         assert config.devices[0].wifi_client_info is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -294,3 +294,32 @@ class TestConfigEdgeCases:
                 password="password",
                 connection_timeout="invalid",
             )
+
+
+class TestWifiClientInfoConfig:
+    def test_wifi_client_info_from_config_dict(self):
+        # File path: parsed YAML dict -> DeviceConfig
+        dev = DeviceConfig.from_config(
+            {
+                "hostname": "fritz.box",
+                "username": "user",
+                "password": "password",
+                "wifi_client_info": True,
+            }
+        )
+        assert dev.wifi_client_info is True
+
+    def test_wifi_client_info_defaults_false(self):
+        dev = DeviceConfig.from_config(
+            {"hostname": "fritz.box", "username": "user", "password": "password"}
+        )
+        assert dev.wifi_client_info is False
+
+    def test_wifi_client_info_from_env(self, monkeypatch):
+        # Env path: FRITZ_WIFI_CLIENT_INFO -> DeviceConfig
+        monkeypatch.setenv("FRITZ_USERNAME", "user")
+        monkeypatch.setenv("FRITZ_PASSWORD", "password")
+        monkeypatch.setenv("FRITZ_WIFI_CLIENT_INFO", "True")
+
+        config = get_config(None)
+        assert config.devices[0].wifi_client_info is True

--- a/tests/test_datadonation.py
+++ b/tests/test_datadonation.py
@@ -234,7 +234,8 @@ class TestDataDonation:
             '"LanInterfaceConfig", "LanInterfaceConfigStatistics", "WanDSLInterfaceConfig", '
             '"WanDSLInterfaceConfigAVM", "WanPPPConnectionStatus", "WanCommonInterfaceConfig", '
             '"WanCommonInterfaceDataBytes", "WanCommonInterfaceByteRate", '
-            '"WanCommonInterfaceDataPackets", "WlanConfigurationInfo", "HostInfo", '
+            '"WanCommonInterfaceDataPackets", "WlanConfigurationInfo", "WlanAssociatedDevices", '
+            '"HostInfo", '
             '"HomeAutomation"], "action_results": {"Hosts1": {"GetHostNumberOfEntries": '
             '{"NewHostNumberOfEntries": "3"}}}}}',
             headers={"Content-Type": "application/json"},timeout=10,

--- a/tests/test_fritzcapabilities.py
+++ b/tests/test_fritzcapabilities.py
@@ -52,7 +52,7 @@ class TestFritzCapabilitiesMethods:
         num_caps = len(fd.capabilities)
 
         # Check
-        assert num_caps == 15  # All known capabilities
+        assert num_caps == 16  # All known capabilities
 
     def test_empty_capabilities_is_true_when_all_absent(self, mock_fritzconnection: MagicMock):
         # Prepare - use an empty service set so no capability is present

--- a/tests/test_fritzdevice.py
+++ b/tests/test_fritzdevice.py
@@ -282,6 +282,7 @@ class TestFritzCollector:
             "WanCommonInterfaceByteRate",
             "WanCommonInterfaceDataPackets",
             "WlanConfigurationInfo",
+            "WlanAssociatedDevices",
             "HostInfo",
             "HomeAutomation",
         ]
@@ -632,6 +633,71 @@ class TestFritzCollector:
         # Check: no fritz_connection_mode metric should be in results
         metric_names = [m.name for m in metrics]
         assert "fritz_connection_mode" not in metric_names
+
+    def test_should_collect_wifi_client_info_when_enabled(
+        self, mock_fritzconnection: MagicMock, caplog
+    ):
+        # Opt-in per-station metrics: with wifi_client_info=True the exporter emits
+        # one signal/speed sample per associated client per detected radio.
+        caplog.set_level(logging.DEBUG)
+
+        fc = mock_fritzconnection.return_value
+        fc.call_action.side_effect = call_action_mock
+        fc.services = create_fc_services(fc_services_capabilities["WlanConfigurationInfo"])
+
+        collector = FritzCollector()
+        device = FritzDevice(
+            FritzCredentials("somehost", "someuser", "password"), "FritzMock", wifi_client_info=True
+        )
+        collector.register(device)
+
+        # Two associated clients per radio, with per-index info.
+        def assoc_mock(service, action, **kwargs):
+            if action == "GetTotalAssociations":
+                return {"NewTotalAssociations": 2}
+            if action == "GetGenericAssociatedDeviceInfo":
+                i = kwargs["NewAssociatedDeviceIndex"]
+                return {
+                    "NewAssociatedDeviceMACAddress": f"AA:BB:CC:00:00:0{i}",
+                    "NewAssociatedDeviceIPAddress": f"192.168.178.{i}",
+                    "NewX_AVM-DE_SignalStrength": 80 - i,
+                    "NewX_AVM-DE_Speed": 100 + i,
+                }
+            return call_action_mock(service, action, **kwargs)
+
+        fc.call_action.side_effect = assoc_mock
+
+        # Act
+        metrics: list[Metric] = list(collector.collect())
+
+        # Check: signal metric present, 2 clients on each of the 2 detected radios
+        signal = [m for m in metrics if m.name == "fritz_wifi_client_signal_strength"]
+        assert len(signal) == 1
+        assert len(signal[0].samples) == 4
+        assert any(s.labels["client_mac"] == "AA:BB:CC:00:00:00" for s in signal[0].samples)
+        assert any(s.labels["wifi_name"] == "2.4GHz" for s in signal[0].samples)
+
+    def test_should_not_collect_wifi_client_info_by_default(
+        self, mock_fritzconnection: MagicMock, caplog
+    ):
+        # Without the opt-in flag the capability stays disabled (no per-client samples).
+        caplog.set_level(logging.DEBUG)
+
+        fc = mock_fritzconnection.return_value
+        fc.call_action.side_effect = call_action_mock
+        fc.services = create_fc_services(fc_services_capabilities["WlanConfigurationInfo"])
+
+        collector = FritzCollector()
+        device = FritzDevice(FritzCredentials("somehost", "someuser", "password"), "FritzMock")
+        collector.register(device)
+
+        # Act
+        metrics: list[Metric] = list(collector.collect())
+
+        # Check: metric family is exposed but empty (capability not enabled)
+        signal = [m for m in metrics if m.name == "fritz_wifi_client_signal_strength"]
+        assert len(signal) == 1
+        assert len(signal[0].samples) == 0
 
 
 @patch("fritzexporter.fritzdevice.FritzConnection")


### PR DESCRIPTION
## Summary
Adds a new `WlanAssociatedDevices` capability that exposes **per-associated-station**
WiFi metrics — signal strength and negotiated link speed — for the FRITZ!Box and for
mesh repeaters:

- `fritz_wifi_client_signal_strength{serial, friendly_name, wifi_name, client_mac, client_ip}`
- `fritz_wifi_client_speed{serial, friendly_name, wifi_name, client_mac, client_ip}`

Data comes from `WLANConfiguration{n}` → `GetTotalAssociations` +
`GetGenericAssociatedDeviceInfo` (`NewX_AVM-DE_SignalStrength`, `NewX_AVM-DE_Speed`).

## Motivation
Today the exporter only reports the *count* of associations per radio
(`fritz_wifi_associations`). In a mesh, clients roam to the repeaters, so the box's
aggregate counts hide where clients actually are and how good their link is. Per-station
signal/speed makes it possible to spot weak clients and see which AP a client is on.

## Opt-in (cardinality)
This emits **one time series per connected client**, so it is **disabled by default**
and enabled per device via:
- config file: `wifi_client_info: true`
- env var: `FRITZ_WIFI_CLIENT_INFO=1`

This mirrors the existing `host_info` opt-in. The flag is wired through both config
paths (file + env), the `DeviceConfig` attrs validators/converters, and the
offline-device retry path, per the "keep both paths in sync" rule in AGENTS.md.

## Tests
- `WlanAssociatedDevices`: collects signal/speed per client per detected radio when
  enabled; exposes empty metric families when the flag is off.
- Config: `wifi_client_info` parsed from both the config-file dict and the env var.
- Updated the capability-count / capability-list / data-donation assertions for the
  new capability.

## Docs / Helm
- `docs/configuration.rst`: new env-var table row, YAML example line, and a note about
  the per-client cardinality. (Also realigned the env-var grid table, which had a
  pre-existing misaligned row.)
- `helm/fritz-exporter/values.yaml`: documented the new key.
- No Dockerfile change required.

## Note on mesh repeaters
On a WAN-less mesh repeater this capability only yields data once the device is no
longer marked unavailable by the WAN-based connection-mode probe — see the companion
fix in `fix/keep-wanless-devices-available` (PR #632). On the FRITZ!Box it works
standalone. Recommend merging the fix PR first.