### PR TITLE
feat(capabilities): add mesh backhaul link metrics (MeshTopology)

### DIFF
--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -970,7 +970,9 @@ class MeshTopology(FritzCapability):
 
     def _generate_metric_values(self, device: FritzDevice) -> None:
         try:
-            topology = FritzHosts(fc=device.fc).get_mesh_topology()
+            # get_mesh_topology is annotated dict | str (str only when raw=True);
+            # with the default raw=False it always returns the parsed dict.
+            topology = cast("dict[str, Any]", FritzHosts(fc=device.fc).get_mesh_topology())
         except FritzActionError:
             # Only the mesh master can serve the topology; every other node answers
             # "Device has no access to topology information" (404). That is the normal

--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -16,6 +16,7 @@ from fritzconnection.core.exceptions import (  # type: ignore[import]
     FritzLookUpError,
     FritzServiceError,
 )
+from fritzconnection.lib.fritzhosts import FritzHosts  # type: ignore[import]
 from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
 
 from fritzexporter.fritz_aha import parse_aha_device_xml
@@ -933,6 +934,96 @@ class WlanAssociatedDevices(FritzCapability):
     ) -> Iterator[CounterMetricFamily | GaugeMetricFamily]:
         yield self.metrics["signal"]
         yield self.metrics["speed"]
+
+
+class MeshTopology(FritzCapability):
+    """Mesh backhaul link quality, read from the mesh master.
+
+    Exposes the current/peak data rate and the state of each backhaul link between
+    mesh nodes (e.g. FRITZ!Box <-> repeater), parsed from the mesh topology
+    (``Hosts1`` ``X_AVM-DE_GetMeshListPath``). Only the mesh master exposes the full
+    topology, so the capability is present only there. Client links are intentionally
+    excluded to keep cardinality bounded (one series per backhaul link, not per client).
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.requirements.append(("Hosts1", "X_AVM-DE_GetMeshListPath"))
+
+    def create_metrics(self) -> None:
+        link_labels = ["serial", "friendly_name", "node", "peer", "type", "direction"]
+        self.metrics["datarate"] = GaugeMetricFamily(
+            "fritz_mesh_link_current_data_rate_kbps",
+            "Current data rate of a mesh backhaul link in kbit/s",
+            labels=link_labels,
+        )
+        self.metrics["maxdatarate"] = GaugeMetricFamily(
+            "fritz_mesh_link_max_data_rate_kbps",
+            "Maximum data rate of a mesh backhaul link in kbit/s",
+            labels=link_labels,
+        )
+        self.metrics["available"] = GaugeMetricFamily(
+            "fritz_mesh_link_available",
+            "Mesh backhaul link state (1=connected, 0=otherwise)",
+            labels=["serial", "friendly_name", "node", "peer", "type"],
+        )
+
+    def _generate_metric_values(self, device: FritzDevice) -> None:
+        try:
+            topology = FritzHosts(fc=device.fc).get_mesh_topology()
+        except FritzConnectionException:
+            # The mesh list is fetched over HTTP; a transient failure should not
+            # mark the whole device unavailable — just skip mesh metrics this cycle.
+            logger.exception("Failed to retrieve mesh topology from %s", device.host)
+            return
+
+        nodes = topology.get("nodes", [])
+        uid_name = {n["uid"]: (n.get("device_name") or "n/a") for n in nodes if "uid" in n}
+        meshed = {n["uid"] for n in nodes if n.get("uid") and n.get("is_meshed")}
+        seen: set[str] = set()
+        for node in nodes:
+            if not node.get("is_meshed"):
+                continue
+            for interface in node.get("node_interfaces", []):
+                link_type = interface.get("type", "")
+                for link in interface.get("node_links", []):
+                    link_uid = link.get("uid")
+                    n1 = link.get("node_1_uid")
+                    n2 = link.get("node_2_uid")
+                    # Only backhaul (mesh-node <-> mesh-node); dedup the link, which is
+                    # listed once under each endpoint.
+                    if link_uid in seen or n1 not in meshed or n2 not in meshed:
+                        continue
+                    seen.add(link_uid)
+                    base = [
+                        device.serial,
+                        device.friendly_name,
+                        uid_name[n1],
+                        uid_name[n2],
+                        link_type,
+                    ]
+                    self.metrics["available"].add_metric(
+                        base, 1.0 if link.get("state") == "CONNECTED" else 0.0
+                    )
+                    self.metrics["datarate"].add_metric(
+                        [*base, "rx"], link.get("cur_data_rate_rx", 0)
+                    )
+                    self.metrics["datarate"].add_metric(
+                        [*base, "tx"], link.get("cur_data_rate_tx", 0)
+                    )
+                    self.metrics["maxdatarate"].add_metric(
+                        [*base, "rx"], link.get("max_data_rate_rx", 0)
+                    )
+                    self.metrics["maxdatarate"].add_metric(
+                        [*base, "tx"], link.get("max_data_rate_tx", 0)
+                    )
+
+    def _get_metric_values(
+        self,
+    ) -> Iterator[CounterMetricFamily | GaugeMetricFamily]:
+        yield self.metrics["datarate"]
+        yield self.metrics["maxdatarate"]
+        yield self.metrics["available"]
 
 
 class HostInfo(FritzCapability):

--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -971,10 +971,17 @@ class MeshTopology(FritzCapability):
     def _generate_metric_values(self, device: FritzDevice) -> None:
         try:
             topology = FritzHosts(fc=device.fc).get_mesh_topology()
+        except FritzActionError:
+            # Only the mesh master can serve the topology; every other node answers
+            # "Device has no access to topology information" (404). That is the normal
+            # case for mesh slaves/repeaters, so log it quietly and skip mesh metrics
+            # for this device — do NOT mark it unavailable.
+            logger.debug("No mesh topology available from %s (not the mesh master)", device.host)
+            return
         except FritzConnectionException:
             # The mesh list is fetched over HTTP; a transient failure should not
             # mark the whole device unavailable — just skip mesh metrics this cycle.
-            logger.exception("Failed to retrieve mesh topology from %s", device.host)
+            logger.warning("Failed to retrieve mesh topology from %s", device.host)
             return
 
         nodes = topology.get("nodes", [])

--- a/tests/test_datadonation.py
+++ b/tests/test_datadonation.py
@@ -235,7 +235,7 @@ class TestDataDonation:
             '"WanDSLInterfaceConfigAVM", "WanPPPConnectionStatus", "WanCommonInterfaceConfig", '
             '"WanCommonInterfaceDataBytes", "WanCommonInterfaceByteRate", '
             '"WanCommonInterfaceDataPackets", "WlanConfigurationInfo", "WlanAssociatedDevices", '
-            '"HostInfo", '
+            '"MeshTopology", "HostInfo", '
             '"HomeAutomation"], "action_results": {"Hosts1": {"GetHostNumberOfEntries": '
             '{"NewHostNumberOfEntries": "3"}}}}}',
             headers={"Content-Type": "application/json"},timeout=10,

--- a/tests/test_fritzcapabilities.py
+++ b/tests/test_fritzcapabilities.py
@@ -52,7 +52,7 @@ class TestFritzCapabilitiesMethods:
         num_caps = len(fd.capabilities)
 
         # Check
-        assert num_caps == 16  # All known capabilities
+        assert num_caps == 17  # All known capabilities
 
     def test_empty_capabilities_is_true_when_all_absent(self, mock_fritzconnection: MagicMock):
         # Prepare - use an empty service set so no capability is present

--- a/tests/test_fritzdevice.py
+++ b/tests/test_fritzdevice.py
@@ -284,6 +284,7 @@ class TestFritzCollector:
             "WanCommonInterfaceDataPackets",
             "WlanConfigurationInfo",
             "WlanAssociatedDevices",
+            "MeshTopology",
             "HostInfo",
             "HomeAutomation",
         ]
@@ -739,6 +740,91 @@ class TestFritzCollector:
         signal = [m for m in metrics if m.name == "fritz_wifi_client_signal_strength"]
         assert len(signal) == 1
         assert len(signal[0].samples) == 0
+
+    @patch("fritzexporter.fritzcapabilities.FritzHosts")
+    def test_should_collect_mesh_backhaul_links(
+        self, mock_fritzhosts: MagicMock, mock_fritzconnection: MagicMock, caplog
+    ):
+        # The mesh master exports one series per backhaul link between mesh nodes;
+        # client links (to non-meshed devices) are excluded.
+        caplog.set_level(logging.DEBUG)
+
+        def call_with_mesh(service, action, **kwargs):
+            if service == "Hosts1" and action == "X_AVM-DE_GetMeshListPath":
+                return {"NewX_AVM-DE_MeshListPath": "/meshlist.lua"}
+            return call_action_mock(service, action, **kwargs)
+
+        fc = mock_fritzconnection.return_value
+        fc.call_action.side_effect = call_with_mesh
+        fc.services = create_fc_services(fc_services_devices["FritzBox 7590"])
+
+        mock_fritzhosts.return_value.get_mesh_topology.return_value = {
+            "nodes": [
+                {
+                    "uid": "n1",
+                    "device_name": "fritzbox",
+                    "is_meshed": True,
+                    "node_interfaces": [
+                        {
+                            "type": "WLAN",
+                            "node_links": [
+                                {
+                                    "uid": "l1", "node_1_uid": "n1", "node_2_uid": "n2",
+                                    "state": "CONNECTED",
+                                    "cur_data_rate_rx": 71800, "cur_data_rate_tx": 72200,
+                                    "max_data_rate_rx": 144400, "max_data_rate_tx": 144400,
+                                },
+                                {
+                                    "uid": "l2", "node_1_uid": "n1", "node_2_uid": "c1",
+                                    "state": "CONNECTED",
+                                    "cur_data_rate_rx": 100, "cur_data_rate_tx": 100,
+                                    "max_data_rate_rx": 200, "max_data_rate_tx": 200,
+                                },
+                            ],
+                        }
+                    ],
+                },
+                {
+                    "uid": "n2",
+                    "device_name": "repeater",
+                    "is_meshed": True,
+                    "node_interfaces": [
+                        {
+                            "type": "WLAN",
+                            "node_links": [
+                                {
+                                    "uid": "l1", "node_1_uid": "n2", "node_2_uid": "n1",
+                                    "state": "CONNECTED",
+                                    "cur_data_rate_rx": 72200, "cur_data_rate_tx": 71800,
+                                    "max_data_rate_rx": 144400, "max_data_rate_tx": 144400,
+                                }
+                            ],
+                        }
+                    ],
+                },
+                {"uid": "c1", "device_name": "phone", "is_meshed": False, "node_interfaces": []},
+            ]
+        }
+
+        collector = FritzCollector()
+        device = FritzDevice(FritzCredentials("somehost", "someuser", "password"), "FritzMock")
+        collector.register(device)
+
+        # Act
+        metrics: list[Metric] = list(collector.collect())
+
+        # Check: exactly one backhaul link (l1, deduped), client link l2 excluded
+        available = [m for m in metrics if m.name == "fritz_mesh_link_available"]
+        assert len(available) == 1
+        assert len(available[0].samples) == 1
+        sample = available[0].samples[0]
+        assert sample.value == 1.0
+        assert {sample.labels["node"], sample.labels["peer"]} == {"fritzbox", "repeater"}
+        assert all(s.labels["peer"] != "phone" for s in available[0].samples)
+
+        # rx + tx series for the single backhaul link
+        datarate = [m for m in metrics if m.name == "fritz_mesh_link_current_data_rate_kbps"]
+        assert len(datarate[0].samples) == 2
 
 
 @patch("fritzexporter.fritzdevice.FritzConnection")


### PR DESCRIPTION
## Summary
Adds a `MeshTopology` capability that parses the mesh topology
(`Hosts1` `X_AVM-DE_GetMeshListPath`, via `FritzHosts.get_mesh_topology()`) and
exports, for each backhaul link between mesh nodes:

- `fritz_mesh_link_current_data_rate_kbps{node, peer, type, direction}`
- `fritz_mesh_link_max_data_rate_kbps{node, peer, type, direction}`
- `fritz_mesh_link_available{node, peer, type}`

## Motivation
Per-client metrics (counts/signal) don't show **backhaul** health. A repeater whose
uplink degrades before it drops out is invisible today. The mesh master already knows
the whole graph including backhaul link data rates — this exposes it.

## Scope / cardinality
- **Backhaul links only** (mesh-node ↔ mesh-node); client links are excluded, so this
  is one series per link (~number of repeaters), not per client.
- Links are deduped (each link is listed under both endpoints).
- **No opt-in flag and no config change**: the capability is simply absent on devices
  that don't expose the mesh list, so it is effectively master-only.
- A transient mesh-list fetch failure is caught and the cycle skipped, without marking
  the device unavailable.

## Tests
Backhaul links collected + deduped, client links excluded (via a patched
`FritzHosts` returning a canned topology). Capability count / list / data-donation
assertions updated.
