### PR TITLE
chore(claude): allow gh pr commands in shared settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,8 @@
     "allow": [
       "mcp__sonarqube__search_my_sonarqube_projects",
       "mcp__sonarqube__get_project_quality_gate_status",
-      "mcp__sonarqube__search_sonar_issues_in_projects"
+      "mcp__sonarqube__search_sonar_issues_in_projects",
+      "Bash(gh pr *)"
     ]
   }
 }


### PR DESCRIPTION
## What

Add `Bash(gh pr *)` to the team-shared `.claude/settings.json` allowlist.

## Why

Contributors using Claude Code currently get prompted for PR operations. `gh pr` usage is read-heavy and broadly safe, so blessing it in the shared settings (not the gitignored `settings.local.json`) is appropriate for the whole team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)