### PR TITLE
ops(ci): skip SonarCloud scan on fork PRs so tests still run

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -44,6 +44,9 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
           exit $rescode
       - name: SonarCloud Scan
+        # Secrets (SONAR_TOKEN) are not available to PRs from forks, so the
+        # scan would fail. Skip it for external PRs; lint and tests still run.
+        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: SonarSource/sonarqube-scan-action@v8.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

For PRs from forks, GitHub does not expose repository secrets to the workflow (to prevent a fork author from exfiltrating `SONAR_TOKEN`). As a result `SONAR_TOKEN` is empty, the `SonarCloud Scan` step fails, and it takes the whole `Run Tests` job down with it — even when lint and pytest passed.

## Change

Gate the SonarCloud step so it only runs when secrets are actually available:

- **Push to `main`** → Sonar runs.
- **PR from a branch in this repo** → Sonar runs.
- **PR from a fork** → Sonar step skipped; lint + pytest still run and report status.

`if:` conditions cannot read `secrets.*`, so the standard idiom of testing the head repo identity (`github.event.pull_request.head.repo.full_name == github.repository`) is used instead.

Sonar coverage of external contributors' PRs is a nice-to-have, not a merge gate, so the more complex `workflow_run` two-workflow pattern was intentionally avoided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)