### PR TITLE
fix(capabilities): keep device reachable when host table shrinks mid-scan

### DIFF
--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -1123,9 +1123,24 @@ class HostInfo(FritzCapability):
         )
         for host_index in range(num_hosts_result["NewHostNumberOfEntries"]):
             logger.debug("Fetching generic host information for host number %s", host_index)
-            host_result = device.fc.call_action(
-                "Hosts1", "GetGenericHostEntry", NewIndex=host_index
-            )
+            try:
+                host_result = device.fc.call_action(
+                    "Hosts1", "GetGenericHostEntry", NewIndex=host_index
+                )
+            except FritzArrayIndexError:
+                # The host table shrank between GetHostNumberOfEntries and this read
+                # (a client left mid-scan), so this index is now out of range
+                # (UPnP errorCode 713, SpecifiedArrayIndexInvalid). This is a benign
+                # race on the DHCP server's host table, not a device outage: stop
+                # enumerating and keep the hosts collected so far. Letting it bubble
+                # up would flip the whole device to unreachable for this cycle.
+                logger.debug(
+                    "Host table shrank during scan of device serial %s at index %s; "
+                    "stopping host enumeration for this cycle",
+                    device.serial,
+                    host_index,
+                )
+                break
             host_ip = host_result["NewIPAddress"]
             host_mac = host_result["NewMACAddress"]
             host_name = host_result["NewHostName"]

--- a/tests/test_fritzcapabilities.py
+++ b/tests/test_fritzcapabilities.py
@@ -170,6 +170,61 @@ class TestHostInfoCapability:
         assert sample.labels["model"] == "n/a"
         assert sample.value == 0.0
 
+    def test_host_table_shrinking_mid_scan_keeps_device_reachable(
+        self, mock_fritzconnection: MagicMock, caplog
+    ):
+        # A host leaving mid-scan makes GetGenericHostEntry raise FritzArrayIndexError
+        # (UPnP errorCode 713, SpecifiedArrayIndexInvalid). This is a benign race on the
+        # DHCP server's host table, not a device outage: the box is fully reachable, the
+        # host table just shrank between GetHostNumberOfEntries and the per-index reads.
+        # The device must stay reachable and the hosts read before the error must still
+        # be exported.
+        caplog.set_level(logging.DEBUG)
+
+        fc = mock_fritzconnection.return_value
+
+        def shrinking_table_mock(service, action, **kwargs):
+            if service == "Hosts1" and action == "GetHostNumberOfEntries":
+                return {"NewHostNumberOfEntries": 3}
+            if service == "Hosts1" and action == "GetGenericHostEntry":
+                index = kwargs.get("NewIndex", 0)
+                if index >= 2:
+                    # table shrank from 3 to 2 hosts while we were iterating
+                    raise FritzArrayIndexError
+                return {
+                    "NewIPAddress": "",  # empty IP -> skip the AVM specific-entry lookup
+                    "NewMACAddress": f"AA:BB:CC:DD:EE:0{index}",
+                    "NewHostName": f"host-{index}",
+                    "NewActive": 1,
+                }
+            return call_action_mock(service, action, **kwargs)
+
+        fc.call_action.side_effect = shrinking_table_mock
+        fc.services = create_fc_services(fc_services_devices["FritzBox 7590"])
+
+        collector = FritzCollector()
+        device = FritzDevice(
+            FritzCredentials("somehost", "someuser", "password"), "FritzMock", host_info=True
+        )
+        collector.register(device)
+
+        # Act
+        metrics: list[Metric] = list(collector.collect())
+
+        # Check - device stays reachable despite the mid-scan table shrink
+        reachable_metrics = [m for m in metrics if m.name == "fritz_device_reachable"]
+        assert len(reachable_metrics) == 1
+        fritzmock_samples = [
+            s for s in reachable_metrics[0].samples if s.labels["friendly_name"] == "FritzMock"
+        ]
+        assert len(fritzmock_samples) == 1
+        assert fritzmock_samples[0].value == 1.0
+
+        # Check - the hosts read before the error are still exported (graceful degradation)
+        host_active_metrics = [m for m in metrics if m.name == "fritz_host_active"]
+        assert len(host_active_metrics) == 1
+        assert len(host_active_metrics[0].samples) == 2
+
 
 @patch("fritzexporter.fritzdevice.FritzConnection")
 class TestHomeAutomationCapability:


### PR DESCRIPTION
## Problem

On a FRITZ!Box with `host_info` enabled, `fritz_device_reachable` flaps to `0`
even though the box is fully up. On my setup (FRITZ!Box 6490 acting as the LAN's
DHCP server, plus five mesh repeaters) the router showed `reachable == 0` for
**26.7 % of all scrapes over an 18 h window**, while every other mesh device —
none of which have `host_info` — sat at ~0 %:

| device | `host_info` | `reachable == 0` (same 18 h window) |
|--------|:-----------:|:-----------------------------------:|
| router | **on**      | **26.7 %**                          |
| rpt 1  | off         | 0.09 %                              |
| rpt 2–5| off         | 0.00 %                              |

The exporter log at those timestamps:
```
ERROR fritzexporter.fritzcapability | Device 192.168.178.1 is unreachable,
skipping HostInfo metrics for this collection cycle
fritzconnection.core.exceptions.FritzArrayIndexError: UPnPError:
errorCode: 713
errorDescription: SpecifiedArrayIndexInvalid
```

## Root cause
`HostInfo._generate_metric_values` reads `GetHostNumberOfEntries` (N) and then
iterates `GetGenericHostEntry(NewIndex=0..N-1)`. That scan takes ~16 s on this
box. When a Wi-Fi client leaves *during* the scan the host table shrinks, so a
trailing index is no longer valid and the box returns UPnP **713
(SpecifiedArrayIndexInvalid)**.
`FritzArrayIndexError` is a subclass of `FritzConnectionException`, so the broad
handler in `FritzCapability.get_metrics` catches it, sets
`device.available = False`, and `collect()` then emits
`fritz_device_reachable = 0` for the **whole** scrape. A benign host-table race
gets reported as a router outage.
## Fix
Catch `FritzArrayIndexError` inside the host-enumeration loop and stop
enumerating for that cycle, keeping the hosts already collected. A shrinking host
table is normal on a busy network and says nothing about reachability, so it must
not bubble up to the availability handler.
## Testing
**Unit test** (added, written test-first):
`TestHostInfoCapability::test_host_table_shrinking_mid_scan_keeps_device_reachable`
mocks `GetHostNumberOfEntries → 3` with `GetGenericHostEntry` raising
`FritzArrayIndexError` at index 2, and asserts the device stays reachable and the
hosts read before the error are still exported. Fails on `main`, passes with the
fix. Full suite: **125 passed**.
**Real hardware** — ran the patched build against the same live box with
`DEBUG` logging and caught a natural mid-scan shrink:
```
DEBUG ... Fetching host information for device serial <redacted> (hosts found: 72
DEBUG ... Host table shrank during scan of device serial <redacted> at index 68;
stopping host enumeration for this cycle
```

In the same scrape `fritz_device_reachable{...} 1.0`, with the 68 hosts read
before the shrink still exported. Over the whole run the "device unreachable"
handler fired **0 times** (was a constant stream before). Result on the same
router: **26.7 % false-unreachable → 0 %**.