### PR TITLE
test(capabilities): add log regression assertion and fix lint order

### DIFF
--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Generator, Iterator, ItemsView
+from collections.abc import Generator, ItemsView, Iterator
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 

--- a/tests/test_fritzcapabilities.py
+++ b/tests/test_fritzcapabilities.py
@@ -225,6 +225,18 @@ class TestHostInfoCapability:
         assert len(host_active_metrics) == 1
         assert len(host_active_metrics[0].samples) == 2
 
+        # Check - benign shrink path is logged and no unreachable error is emitted
+        assert any(
+            "Host table shrank during scan of device serial" in record.message
+            for record in caplog.records
+            if record.levelno == logging.DEBUG
+        )
+        assert not any(
+            "is unreachable, skipping HostInfo metrics for this collection cycle"
+            in record.message
+            for record in caplog.records
+        )
+
 
 @patch("fritzexporter.fritzdevice.FritzConnection")
 class TestHomeAutomationCapability:


### PR DESCRIPTION
## Summary
- add a regression assertion that the benign host-table shrink path logs a debug message
- assert no unreachable HostInfo error log is emitted for that benign race
- fix import ordering in `fritzexporter/fritzcapabilities.py` to satisfy ruff

## Testing
- `uv run ruff check fritzexporter/`
- `uv run pytest -q`