### PR TITLE
fix(capabilities): disambiguate concurrent same-type mesh backhaul links

### DIFF
--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -944,6 +944,13 @@ class MeshTopology(FritzCapability):
     (``Hosts1`` ``X_AVM-DE_GetMeshListPath``). Only the mesh master exposes the full
     topology, so the capability is present only there. Client links are intentionally
     excluded to keep cardinality bounded (one series per backhaul link, not per client).
+
+    A node pair can have more than one concurrent backhaul link of the same
+    ``type`` (e.g. simultaneous 2.4GHz + 5GHz WLAN backhaul) - the ``interface``
+    label (the reporting side's own ``node_interfaces`` name, e.g. ``AP:5G:0``)
+    distinguishes those. AVM also reports each physical link twice - once under
+    each endpoint's own node record, with identical uid and data both times -
+    which is deduped below; that's a genuine duplicate, not a second link.
     """
 
     def __init__(self) -> None:
@@ -951,7 +958,15 @@ class MeshTopology(FritzCapability):
         self.requirements.append(("Hosts1", "X_AVM-DE_GetMeshListPath"))
 
     def create_metrics(self) -> None:
-        link_labels = ["serial", "friendly_name", "node", "peer", "type", "direction"]
+        link_labels = [
+            "serial",
+            "friendly_name",
+            "node",
+            "peer",
+            "type",
+            "interface",
+            "direction",
+        ]
         self.metrics["datarate"] = GaugeMetricFamily(
             "fritz_mesh_link_current_data_rate_kbps",
             "Current data rate of a mesh backhaul link in kbit/s",
@@ -965,7 +980,7 @@ class MeshTopology(FritzCapability):
         self.metrics["available"] = GaugeMetricFamily(
             "fritz_mesh_link_available",
             "Mesh backhaul link state (1=connected, 0=otherwise)",
-            labels=["serial", "friendly_name", "node", "peer", "type"],
+            labels=["serial", "friendly_name", "node", "peer", "type", "interface"],
         )
 
     def _generate_metric_values(self, device: FritzDevice) -> None:
@@ -995,12 +1010,17 @@ class MeshTopology(FritzCapability):
                 continue
             for interface in node.get("node_interfaces", []):
                 link_type = interface.get("type", "")
+                interface_name = interface.get("name", "")
                 for link in interface.get("node_links", []):
                     link_uid = link.get("uid")
                     n1 = link.get("node_1_uid")
                     n2 = link.get("node_2_uid")
-                    # Only backhaul (mesh-node <-> mesh-node); dedup the link, which is
-                    # listed once under each endpoint.
+                    # Only backhaul (mesh-node <-> mesh-node). Each physical link is
+                    # listed once under each endpoint's own node record with identical
+                    # uid and data both times, so dedup by uid to avoid double-counting
+                    # that one fact - a node pair can still have multiple concurrent
+                    # links of the same type (e.g. 2.4GHz + 5GHz backhaul), which are
+                    # distinct uids and stay separate, disambiguated by `interface`.
                     if link_uid in seen or n1 not in meshed or n2 not in meshed:
                         continue
                     seen.add(link_uid)
@@ -1010,6 +1030,7 @@ class MeshTopology(FritzCapability):
                         uid_name[n1],
                         uid_name[n2],
                         link_type,
+                        interface_name,
                     ]
                     self.metrics["available"].add_metric(
                         base, 1.0 if link.get("state") == "CONNECTED" else 0.0

--- a/tests/test_fritzdevice.py
+++ b/tests/test_fritzdevice.py
@@ -746,7 +746,12 @@ class TestFritzCollector:
         self, mock_fritzhosts: MagicMock, mock_fritzconnection: MagicMock, caplog
     ):
         # The mesh master exports one series per backhaul link between mesh nodes;
-        # client links (to non-meshed devices) are excluded.
+        # client links (to non-meshed devices) are excluded. A node pair can have
+        # more than one concurrent link of the same type (e.g. simultaneous 2.4GHz
+        # + 5GHz WLAN backhaul, as seen on real hardware) - each physical link is
+        # listed once under each endpoint's own node record (same uid, same data
+        # both times - deduped), but distinct links (different uid) between the
+        # same pair must stay separate, disambiguated by the `interface` label.
         caplog.set_level(logging.DEBUG)
 
         def call_with_mesh(service, action, **kwargs):
@@ -767,6 +772,7 @@ class TestFritzCollector:
                     "node_interfaces": [
                         {
                             "type": "WLAN",
+                            "name": "AP:2G:0",
                             "node_links": [
                                 {
                                     "uid": "l1", "node_1_uid": "n1", "node_2_uid": "n2",
@@ -781,7 +787,23 @@ class TestFritzCollector:
                                     "max_data_rate_rx": 200, "max_data_rate_tx": 200,
                                 },
                             ],
-                        }
+                        },
+                        {
+                            "type": "WLAN",
+                            "name": "AP:5G:0",
+                            "node_links": [
+                                {
+                                    # Concurrent 5GHz backhaul to the same peer as l1.
+                                    # AVM reports node_1_uid/node_2_uid reversed here
+                                    # relative to l1, matching what was observed on
+                                    # real hardware.
+                                    "uid": "l3", "node_1_uid": "n2", "node_2_uid": "n1",
+                                    "state": "CONNECTED",
+                                    "cur_data_rate_rx": 288200, "cur_data_rate_tx": 864000,
+                                    "max_data_rate_rx": 2401000, "max_data_rate_tx": 2401000,
+                                },
+                            ],
+                        },
                     ],
                 },
                 {
@@ -791,15 +813,28 @@ class TestFritzCollector:
                     "node_interfaces": [
                         {
                             "type": "WLAN",
+                            "name": "UPLINK:2G:0",
                             "node_links": [
                                 {
-                                    "uid": "l1", "node_1_uid": "n2", "node_2_uid": "n1",
+                                    "uid": "l1", "node_1_uid": "n1", "node_2_uid": "n2",
                                     "state": "CONNECTED",
-                                    "cur_data_rate_rx": 72200, "cur_data_rate_tx": 71800,
+                                    "cur_data_rate_rx": 71800, "cur_data_rate_tx": 72200,
                                     "max_data_rate_rx": 144400, "max_data_rate_tx": 144400,
                                 }
                             ],
-                        }
+                        },
+                        {
+                            "type": "WLAN",
+                            "name": "UPLINK:5G:0",
+                            "node_links": [
+                                {
+                                    "uid": "l3", "node_1_uid": "n2", "node_2_uid": "n1",
+                                    "state": "CONNECTED",
+                                    "cur_data_rate_rx": 288200, "cur_data_rate_tx": 864000,
+                                    "max_data_rate_rx": 2401000, "max_data_rate_tx": 2401000,
+                                },
+                            ],
+                        },
                     ],
                 },
                 {"uid": "c1", "device_name": "phone", "is_meshed": False, "node_interfaces": []},
@@ -813,18 +848,23 @@ class TestFritzCollector:
         # Act
         metrics: list[Metric] = list(collector.collect())
 
-        # Check: exactly one backhaul link (l1, deduped), client link l2 excluded
+        # Check: two distinct backhaul links (l1 2.4GHz + l3 5GHz, each deduped
+        # across both endpoints' reports), client link l2 excluded
         available = [m for m in metrics if m.name == "fritz_mesh_link_available"]
         assert len(available) == 1
-        assert len(available[0].samples) == 1
-        sample = available[0].samples[0]
-        assert sample.value == 1.0
-        assert {sample.labels["node"], sample.labels["peer"]} == {"fritzbox", "repeater"}
+        assert len(available[0].samples) == 2
+        for sample in available[0].samples:
+            assert sample.value == 1.0
+            assert {sample.labels["node"], sample.labels["peer"]} == {"fritzbox", "repeater"}
         assert all(s.labels["peer"] != "phone" for s in available[0].samples)
 
-        # rx + tx series for the single backhaul link
+        # The two links must be disambiguated by `interface`, not collapsed
+        interfaces = {s.labels["interface"] for s in available[0].samples}
+        assert interfaces == {"AP:2G:0", "AP:5G:0"}
+
+        # rx + tx series for each of the two backhaul links
         datarate = [m for m in metrics if m.name == "fritz_mesh_link_current_data_rate_kbps"]
-        assert len(datarate[0].samples) == 2
+        assert len(datarate[0].samples) == 4
 
 
 @patch("fritzexporter.fritzdevice.FritzConnection")


### PR DESCRIPTION
## Summary
- Fixes #645: `fritz_mesh_link_*` metrics could collide on identical labels when a mesh repeater backhauls over more than one band at once (e.g. simultaneous 2.4GHz + 5GHz WLAN backhaul), causing Prometheus's "different value but same timestamp" ingestion warnings on every scrape.
- Root-caused by pulling the raw AVM mesh topology JSON directly: `MeshTopology`'s existing `uid`-based dedup correctly collapses each link's redundant per-endpoint report (same uid, byte-identical data on both sides), but had no label to distinguish two genuinely different concurrent links of the same `type` between the same node pair.
- Adds an `interface` label (the reporting `node_interfaces` entry's own `name`, e.g. `AP:2G:0` / `AP:5G:0`) to `fritz_mesh_link_available`, `fritz_mesh_link_current_data_rate_kbps`, and `fritz_mesh_link_max_data_rate_kbps`.
- The reported `fritz_wifi_*` duplicates in #645 turned out to be a false positive from the reporter's diagnostic command (`sort | uniq -d -w 80` truncates comparisons at 80 characters); an exact-match check found no real WiFi duplicates.

## Test plan
- [x] `uv run pytest tests/test_fritzdevice.py -k mesh -v` — updated mesh test passes, covering two concurrent same-type links (2.4GHz + 5GHz) between the same node pair, disambiguated by `interface`
- [x] `uv run pytest` — full suite passes (one pre-existing, unrelated failure reproduced identically on `main`: a port-already-in-use error from a locally running exporter instance)
- [x] `uv run ruff check fritzexporter/` — clean
- [x] Live-verified against a real FritzBox + mesh repeater running this branch: both bands now appear as distinct series, and an exact-match duplicate check (`curl .../metrics | cut -d" " -f1 | sort | uniq -d`) comes up empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)