### PR TITLE
fix: audit and reduce noqa suppressions

### DIFF
--- a/fritzexporter/__main__.py
+++ b/fritzexporter/__main__.py
@@ -16,6 +16,7 @@ from fritzexporter.config import DeviceConfig, ExporterError, get_config
 from fritzexporter.data_donation import donate_data
 from fritzexporter.exceptions import FritzDeviceHasNoCapabilitiesError
 from fritzexporter.fritzdevice import FritzCollector, FritzCredentials, FritzDevice
+from fritzexporter.tr064_remote import ConnectionOptions
 
 from . import __version__
 
@@ -83,16 +84,19 @@ def _register_device(
 ) -> None:
     password = _resolve_password(dev)
     creds = FritzCredentials(dev.hostname, dev.username, password)
+    connection = ConnectionOptions(
+        connection_timeout=dev.connection_timeout,
+        use_tls=dev.use_tls,
+        port=dev.port,
+        remote_access=dev.remote_access,
+    )
     try:
         fritz_device = FritzDevice(
             creds,
             dev.name,
             host_info=dev.host_info,
             wifi_client_info=dev.wifi_client_info,
-            connection_timeout=dev.connection_timeout,
-            use_tls=dev.use_tls,
-            port=dev.port,
-            remote_access=dev.remote_access,
+            connection=connection,
         )
     except FritzConnectionException, FritzAuthorizationError, FritzDeviceHasNoCapabilitiesError:
         logger.exception(
@@ -105,10 +109,7 @@ def _register_device(
             dev.name,
             host_info=dev.host_info,
             wifi_client_info=dev.wifi_client_info,
-            connection_timeout=dev.connection_timeout,
-            use_tls=dev.use_tls,
-            port=dev.port,
-            remote_access=dev.remote_access,
+            connection=connection,
         )
         return
 

--- a/fritzexporter/data_donation.py
+++ b/fritzexporter/data_donation.py
@@ -22,6 +22,11 @@ logger = logging.getLogger("fritzexporter.donate_data")
 
 _SANITIZED = "<SANITIZED>"
 
+# A sanitation entry is [service, action] (blank the whole action) or
+# [service, action, field] (blank just that field).
+_SANITATION_ENTRY_LEN_WHOLE_ACTION = 2
+_SANITATION_ENTRY_LEN_SINGLE_FIELD = 3
+
 _SANITIZATION_BLACKLIST: dict[tuple[str, str], list[str]] = {
     ("DeviceConfig1", "GetPersistentData"): ["NewPersistentData"],
     ("DeviceConfig1", "X_AVM-DE_GetConfigFile"): ["NewConfigFile"],
@@ -157,10 +162,12 @@ def _apply_custom_sanitization(res: dict[tuple[str, str], dict], sanitation: lis
         svc_action = (entry[0], entry[1])
         if svc_action not in res:
             continue
-        if len(entry) == 2:  # noqa: PLR2004
+        if len(entry) == _SANITATION_ENTRY_LEN_WHOLE_ACTION:
             for field in res[svc_action]:
                 res[svc_action][field] = _SANITIZED
-        elif len(entry) == 3 and entry[2] in res[svc_action]:  # noqa: PLR2004
+        elif (
+            len(entry) == _SANITATION_ENTRY_LEN_SINGLE_FIELD and entry[2] in res[svc_action]
+        ):
             res[svc_action][entry[2]] = _SANITIZED
 
 
@@ -182,7 +189,7 @@ def jsonify_action_results(ar: dict[tuple[str, str], dict]) -> dict[str, dict]:
     return out
 
 
-def upload_data(basedata) -> None:  # noqa: ANN001
+def upload_data(basedata: dict[str, Any]) -> None:
     donation_url = os.getenv("FRITZ_DONATION_URL", "https://fritz.dreker.de/data/donate")
     headers = {"Content-Type": "application/json"}
     resp = requests.post(donation_url, data=json.dumps(basedata), headers=headers, timeout=10)

--- a/fritzexporter/fritzdevice.py
+++ b/fritzexporter/fritzdevice.py
@@ -16,7 +16,7 @@ from prometheus_client.registry import Collector
 
 from fritzexporter.exceptions import FritzDeviceHasNoCapabilitiesError
 from fritzexporter.fritzcapabilities import FritzCapabilities
-from fritzexporter.tr064_remote import create_fritz_connection
+from fritzexporter.tr064_remote import ConnectionOptions, create_fritz_connection
 
 logger = logging.getLogger("fritzexporter.fritzdevice")
 
@@ -42,18 +42,16 @@ class OfflineDevice(NamedTuple):
 
 
 class FritzDevice:
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         creds: FritzCredentials,
         name: str,
         *,
         host_info: bool = False,
         wifi_client_info: bool = False,
-        connection_timeout: int | None = None,
-        use_tls: bool = False,
-        port: int | None = None,
-        remote_access: bool = False,
+        connection: ConnectionOptions | None = None,
     ) -> None:
+        connection = connection or ConnectionOptions()
         self.host: str = creds.host
         self.serial: str = "n/a"
         self.model: str = "n/a"
@@ -73,10 +71,7 @@ class FritzDevice:
                 address=creds.host,
                 user=creds.user,
                 password=creds.password,
-                timeout=connection_timeout,
-                use_tls=use_tls,
-                port=port,
-                remote_access=remote_access,
+                connection=connection,
             )
         except FritzConnectionException:
             logger.exception("unable to connect to %s.", creds.host)
@@ -180,28 +175,26 @@ class FritzCollector(Collector):
         self.devices.append(fritzdev)
         logger.debug("registered device %s (%s) to collector", fritzdev.host, fritzdev.model)
 
-    def register_offline(  # noqa: PLR0913
+    def register_offline(
         self,
         creds: FritzCredentials,
         friendly_name: str,
         *,
         host_info: bool = False,
         wifi_client_info: bool = False,
-        connection_timeout: int | None = None,
-        use_tls: bool = False,
-        port: int | None = None,
-        remote_access: bool = False,
+        connection: ConnectionOptions | None = None,
     ) -> None:
+        connection = connection or ConnectionOptions()
         self.offline_devices.append(
             OfflineDevice(
                 creds,
                 friendly_name,
                 host_info,
-                connection_timeout,
+                connection.connection_timeout,
                 wifi_client_info,
-                use_tls,
-                port,
-                remote_access,
+                connection.use_tls,
+                connection.port,
+                connection.remote_access,
             )
         )
         logger.debug("registered offline device %s (%s) to collector", creds.host, friendly_name)
@@ -215,10 +208,12 @@ class FritzCollector(Collector):
                     offline.friendly_name,
                     host_info=offline.host_info,
                     wifi_client_info=offline.wifi_client_info,
-                    connection_timeout=offline.connection_timeout,
-                    use_tls=offline.use_tls,
-                    port=offline.port,
-                    remote_access=offline.remote_access,
+                    connection=ConnectionOptions(
+                        connection_timeout=offline.connection_timeout,
+                        use_tls=offline.use_tls,
+                        port=offline.port,
+                        remote_access=offline.remote_access,
+                    ),
                 )
                 logger.info(
                     "Device %s (%s) is back online, registering to collector.",

--- a/fritzexporter/tr064_remote.py
+++ b/fritzexporter/tr064_remote.py
@@ -11,6 +11,7 @@ from urllib.parse import urlsplit, urlunsplit
 from xml.etree.ElementTree import ParseError
 
 import requests
+from attrs import define
 from fritzconnection import FritzConnection  # type: ignore[import]
 from fritzconnection.core.exceptions import FritzConnectionException  # type: ignore[import]
 
@@ -66,26 +67,34 @@ def remote_tr064_session(*, enabled: bool) -> Iterator[None]:
         requests.Session = original_session  # type: ignore[misc]
 
 
-def create_fritz_connection(  # noqa: PLR0913
+@define(frozen=True)
+class ConnectionOptions:
+    """TR-064 connection options shared by ``FritzDevice`` and ``create_fritz_connection``."""
+
+    connection_timeout: float | tuple[float, float] | None = None
+    use_tls: bool = False
+    port: int | None = None
+    remote_access: bool = False
+
+
+def create_fritz_connection(
     *,
     address: str,
     user: str,
     password: str,
-    timeout: float | tuple[float, float] | None,
-    use_tls: bool,
-    port: int | None,
-    remote_access: bool = False,
+    connection: ConnectionOptions | None = None,
 ) -> FritzConnection:
     """Create a FritzConnection, optionally rewriting paths for WAN remote access."""
-    with remote_tr064_session(enabled=remote_access):
+    options = connection or ConnectionOptions()
+    with remote_tr064_session(enabled=options.remote_access):
         try:
             return FritzConnection(
                 address=address,
                 user=user,
                 password=password,
-                timeout=timeout,
-                use_tls=use_tls,
-                port=port,
+                timeout=options.connection_timeout,
+                use_tls=options.use_tls,
+                port=options.port,
             )
         except ParseError as err:
             # Fritz returns HTML (often text/html; charset=utf-8) for missing/auth

--- a/tests/test_fritzdevice.py
+++ b/tests/test_fritzdevice.py
@@ -14,6 +14,7 @@ from prometheus_client.core import Metric
 from fritzexporter.exceptions import FritzDeviceHasNoCapabilitiesError
 from fritzexporter.fritzdevice import FritzCollector, FritzCredentials, FritzDevice
 from fritzexporter.fritz_aha import parse_aha_device_xml
+from fritzexporter.tr064_remote import ConnectionOptions
 
 from .fc_services_mock import (
     call_action_mock,
@@ -239,7 +240,7 @@ class TestFritzDevice:
         _ = FritzDevice(
             FritzCredentials("somehost", "someuser", "password"),
             "FritzMock",
-            connection_timeout=10,
+            connection=ConnectionOptions(connection_timeout=10),
         )
 
         # Check: timeout must be forwarded to FritzConnection
@@ -279,8 +280,7 @@ class TestFritzDevice:
         _ = FritzDevice(
             FritzCredentials("somehost", "someuser", "password"),
             "FritzMock",
-            use_tls=True,
-            port=49443,
+            connection=ConnectionOptions(use_tls=True, port=49443),
         )
 
         assert mock_fritzconnection.call_args == call(
@@ -614,7 +614,9 @@ class TestFritzCollector:
         creds = FritzCredentials("offlinehost", "user", "pass")
 
         # Act
-        collector.register_offline(creds, "OfflineDevice", connection_timeout=15)
+        collector.register_offline(
+            creds, "OfflineDevice", connection=ConnectionOptions(connection_timeout=15)
+        )
 
         # Check: timeout stored so that retry uses the same bound
         assert len(collector.offline_devices) == 1
@@ -630,7 +632,9 @@ class TestFritzCollector:
 
         collector = FritzCollector()
         creds = FritzCredentials("somehost", "someuser", "password")
-        collector.register_offline(creds, "FritzMock", connection_timeout=7)
+        collector.register_offline(
+            creds, "FritzMock", connection=ConnectionOptions(connection_timeout=7)
+        )
 
         # Device comes back during retry
         fc.call_action.side_effect = call_action_mock
@@ -654,7 +658,9 @@ class TestFritzCollector:
         creds = FritzCredentials("offlinehost", "user", "pass")
 
         collector.register_offline(
-            creds, "OfflineDevice", use_tls=True, port=49443, remote_access=True
+            creds,
+            "OfflineDevice",
+            connection=ConnectionOptions(use_tls=True, port=49443, remote_access=True),
         )
 
         assert len(collector.offline_devices) == 1
@@ -671,7 +677,9 @@ class TestFritzCollector:
         collector = FritzCollector()
         creds = FritzCredentials("somehost", "someuser", "password")
         collector.register_offline(
-            creds, "FritzMock", use_tls=True, port=49443, remote_access=True
+            creds,
+            "FritzMock",
+            connection=ConnectionOptions(use_tls=True, port=49443, remote_access=True),
         )
 
         fc.call_action.side_effect = call_action_mock

--- a/tests/test_tr064_remote.py
+++ b/tests/test_tr064_remote.py
@@ -4,6 +4,7 @@ import requests
 from requests.adapters import HTTPAdapter
 
 from fritzexporter.tr064_remote import (
+    ConnectionOptions,
     Tr064RemoteAccessSession,
     create_fritz_connection,
     rewrite_tr064_remote_url,
@@ -96,10 +97,7 @@ class TestCreateFritzConnection:
             address="box.example",
             user="user",
             password="pass",
-            timeout=None,
-            use_tls=True,
-            port=11243,
-            remote_access=True,
+            connection=ConnectionOptions(use_tls=True, port=11243, remote_access=True),
         )
 
         assert len(captured_sessions) == 1
@@ -127,8 +125,5 @@ class TestCreateFritzConnection:
                 address="box.example",
                 user="user",
                 password="pass",
-                timeout=None,
-                use_tls=True,
-                port=11243,
-                remote_access=True,
+                connection=ConnectionOptions(use_tls=True, port=11243, remote_access=True),
             )


### PR DESCRIPTION
## Summary

Closes #655.

- Introduces `ConnectionOptions` (`fritzexporter/tr064_remote.py`) bundling `connection_timeout`/`use_tls`/`port`/`remote_access`, replacing individual keyword arguments across `FritzDevice.__init__`, `FritzCollector.register_offline`, and `create_fritz_connection`. Removes the three `PLR0913` (too many arguments) suppressions, including the constructor and offline-device registration path called out in the issue.
- Annotates `data_donation.upload_data`'s `basedata` parameter instead of suppressing `ANN001`.
- Replaces magic length checks in `data_donation._apply_custom_sanitization` with named constants instead of suppressing `PLR2004`.
- Reviewed all remaining suppressions (`T201` for `--version` output, two `S104` false positives on non-binding string values, `FBT001` on an attrs validator's fixed call signature) — confirmed necessary and narrowly scoped, left as-is.
- Updated all affected test call sites to construct/pass `ConnectionOptions`.

Note: while working on this I found two pre-existing, unrelated problems on `main` (not touched here, filed separately): #657 (CI silently ignores lint/test failures via `continue-on-error: true`) and #658 (`TestWanFiberCapabilities` patches a stale import path and hits real DNS, causing 4 tests to fail — currently masked by #657).

## Test plan

- [x] `uv run ruff check fritzexporter/` — all checks pass, no more `PLR0913`/`ANN001`/`PLR2004` suppressions
- [x] `uv run pytest` — 153 passed (the 4 failures from #658 are pre-existing on `main` and unrelated to this change)