### PR TITLE
fix: patch FritzConnection at its actual construction site in WanFiber tests

### DIFF
--- a/tests/test_fritzcapabilities.py
+++ b/tests/test_fritzcapabilities.py
@@ -478,7 +478,7 @@ def _sample_map(metric: Metric) -> dict[tuple[tuple[str, str], ...], float]:
     }
 
 
-@patch("fritzexporter.fritzdevice.FritzConnection")
+@patch("fritzexporter.tr064_remote.FritzConnection")
 class TestWanFiberCapabilities:
     """Tests for fibre WAN capability metrics."""
 


### PR DESCRIPTION
## Summary

Closes #658.

`TestWanFiberCapabilities` (added by #650) patches
`@patch("fritzexporter.fritzdevice.FritzConnection")`, but since #652 (WAN
remote TR-064 support), `FritzConnection(...)` is actually constructed inside
`fritzexporter.tr064_remote.create_fritz_connection()`. The stale patch
target meant the mock was never applied — these 4 tests attempted a real DNS
lookup for the literal hostname `"somehost"` and failed:

- `test_fiber_optical_and_sfp_metrics`
- `test_fiber_gpon_metrics_include_serial`
- `test_fiber_statistics_metrics`
- `test_layer1_64bit_max_bitrate_from_addon_infos`

This currently doesn't fail CI only because of #657 (`continue-on-error:
true` swallowing the failure) — fixed separately.

Fix: change the patch target to `@patch("fritzexporter.tr064_remote.FritzConnection")`,
matching the pattern already used correctly in `tests/test_fritzdevice.py`.

## Test plan

- [x] `uv run pytest` — 157 passed (was 153 passed, 4 failed)
- [x] `uv run ruff check .` — unchanged (9 pre-existing, unrelated errors in
  `.github/scripts/check_python_release.py`, addressed in a separate PR)