### PR TITLE
fix: clean up remaining ruff format and lint failures

### DIFF
--- a/.github/scripts/check_python_release.py
+++ b/.github/scripts/check_python_release.py
@@ -35,7 +35,7 @@ def current_minor() -> tuple[int, int]:
 
 
 def newest_stable_cycle() -> tuple[tuple[int, int], str]:
-    with urllib.request.urlopen(ENDOFLIFE_URL, timeout=30) as resp:
+    with urllib.request.urlopen(ENDOFLIFE_URL, timeout=30) as resp:  # noqa: S310
         cycles = json.load(resp)
     best_key: tuple[int, int] | None = None
     best_latest = ""
@@ -55,8 +55,8 @@ def newest_stable_cycle() -> tuple[tuple[int, int], str]:
 
 
 def issue_exists(title: str) -> bool:
-    out = subprocess.run(
-        ["gh", "issue", "list", "--state", "open", "--search", title, "--json", "title"],
+    out = subprocess.run(  # noqa: S603
+        ["gh", "issue", "list", "--state", "open", "--search", title, "--json", "title"],  # noqa: S607
         capture_output=True,
         text=True,
         check=True,
@@ -68,13 +68,13 @@ def main() -> None:
     cur = current_minor()
     newest, latest_patch = newest_stable_cycle()
     if newest <= cur:
-        print(f"Up to date: running {cur[0]}.{cur[1]}, newest stable is {newest[0]}.{newest[1]}")
+        print(f"Up to date: running {cur[0]}.{cur[1]}, newest stable is {newest[0]}.{newest[1]}")  # noqa: T201
         return
 
     version = f"{newest[0]}.{newest[1]}"
     title = f"New stable Python release available: {version}"
     if issue_exists(title):
-        print(f"Issue already open: {title}")
+        print(f"Issue already open: {title}")  # noqa: T201
         return
 
     body = (
@@ -89,9 +89,9 @@ def main() -> None:
     create = ["gh", "issue", "create", "--title", title, "--body", body]
     # Use the label if it exists; otherwise fall back to an unlabelled issue
     # rather than failing the whole run.
-    if subprocess.run([*create, "--label", ISSUE_LABEL]).returncode != 0:
-        subprocess.run(create, check=True)
-    print(f"Opened issue: {title}")
+    if subprocess.run([*create, "--label", ISSUE_LABEL]).returncode != 0:  # noqa: S603, PLW1510
+        subprocess.run(create, check=True)  # noqa: S603
+    print(f"Opened issue: {title}")  # noqa: T201
 
 
 if __name__ == "__main__":

--- a/fritzexporter/data_donation.py
+++ b/fritzexporter/data_donation.py
@@ -165,9 +165,7 @@ def _apply_custom_sanitization(res: dict[tuple[str, str], dict], sanitation: lis
         if len(entry) == _SANITATION_ENTRY_LEN_WHOLE_ACTION:
             for field in res[svc_action]:
                 res[svc_action][field] = _SANITIZED
-        elif (
-            len(entry) == _SANITATION_ENTRY_LEN_SINGLE_FIELD and entry[2] in res[svc_action]
-        ):
+        elif len(entry) == _SANITATION_ENTRY_LEN_SINGLE_FIELD and entry[2] in res[svc_action]:
             res[svc_action][entry[2]] = _SANITIZED
 
 
@@ -248,11 +246,11 @@ def donate_data(
         upload_data(basedata)
     else:
         sys.stdout.write(
-            f"---------------- Donation data for device {model} "
-            "---------------------\n"
+            f"---------------- Donation data for device {model} ---------------------\n"
         )
         sys.stdout.write(f"{json.dumps(basedata, indent=2)}\n")
         sys.stdout.write("----------------- END ------------------\n\n")
+
 
 # Copyright 2019-2026 Patrick Dreker <patrick@dreker.de>
 #

--- a/fritzexporter/fritz_aha.py
+++ b/fritzexporter/fritz_aha.py
@@ -23,6 +23,7 @@ def parse_aha_device_xml(deviceinfo: str) -> dict[str, str]:
     else:
         return result
 
+
 # Copyright 2019-2026 Patrick Dreker <patrick@dreker.de>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -606,16 +606,10 @@ class WanFiberStatistics(FritzCapability):
         self.metrics["packets"].add_metric([*labels, "tx"], result["NewPacketsSent"])
         self.metrics["packets"].add_metric([*labels, "rx"], result["NewPacketsReceived"])
         self.metrics["packet_errors"].add_metric([*labels, "tx"], result["NewPacketErrorsSent"])
-        self.metrics["packet_errors"].add_metric(
-            [*labels, "rx"], result["NewPacketErrorsReceived"]
-        )
+        self.metrics["packet_errors"].add_metric([*labels, "rx"], result["NewPacketErrorsReceived"])
         self.metrics["multicast"].add_metric(labels, result["NewPacketsMulticast"])
-        self.metrics["connection_rate"].add_metric(
-            [*labels, "rx"], result["NewConnectionRateDown"]
-        )
-        self.metrics["connection_rate"].add_metric(
-            [*labels, "tx"], result["NewConnectionRateUp"]
-        )
+        self.metrics["connection_rate"].add_metric([*labels, "rx"], result["NewConnectionRateDown"])
+        self.metrics["connection_rate"].add_metric([*labels, "tx"], result["NewConnectionRateUp"])
 
     def _get_metric_values(
         self,
@@ -1452,10 +1446,19 @@ class HostInfo(FritzCapability):
 
 class HomeAutomation(FritzCapability):
     _HA_LABELS: ClassVar[list[str]] = [
-        "serial", "friendly_name", "ain", "device_name", "device_id", "manufacturer", "productname",
+        "serial",
+        "friendly_name",
+        "ain",
+        "device_name",
+        "device_id",
+        "manufacturer",
+        "productname",
     ]
     _DEVICE_PRESENT_MAP: ClassVar[dict[str, int]] = {
-        "DISCONNECTED": 0, "REGISTERED": 1, "CONNECTED": 2, "UNKNOWN": 3,
+        "DISCONNECTED": 0,
+        "REGISTERED": 1,
+        "CONNECTED": 2,
+        "UNKNOWN": 3,
     }
     _SWITCH_MODE_MAP: ClassVar[dict[str, int]] = {"MANUAL": 0, "AUTO": 1, "UNDEFINED": 2}
     _SWITCH_STATE_MAP: ClassVar[dict[str, int]] = {"OFF": 0, "ON": 1, "TOGGLE": 2, "UNDEFINED": 3}

--- a/fritzexporter/fritzdevice.py
+++ b/fritzexporter/fritzdevice.py
@@ -153,8 +153,7 @@ class FritzDevice:
 
         m = GaugeMetricFamily(
             "fritz_connection_mode",
-            "Connection mode: 1=DSL, 2=Mobile fallback, 3=Mobile-only, 4=Fiber, "
-            "0=offline/unknown",
+            "Connection mode: 1=DSL, 2=Mobile fallback, 3=Mobile-only, 4=Fiber, 0=offline/unknown",
             labels=["serial", "friendly_name", "access_type"],
         )
         m.add_metric([self.serial, self.friendly_name, access_type], mode)


### PR DESCRIPTION
## Summary

`ruff check .` / `ruff format --check .` currently fail on `main`, unrelated to #658 (fixed in #661) — this is the last piece before the CI gate can be hardened to actually fail on lint issues (#657).

- **Formatting drift**: `data_donation.py`, `fritz_aha.py`, `fritzcapabilities.py`, `fritzdevice.py` had drifted out of `ruff format` compliance. Fixed by running `uv run ruff format` — no logic changes.
- **`.github/scripts/check_python_release.py`**: the only file outside the `tests`/`docs` ruff exclusion still failing `ruff check .` (9 errors: `S310`, `S603`×3, `S607`, `T201`×3, `PLW1510`). Added narrow, justified `# noqa` comments rather than excluding the file — it's a small CI helper script where each flagged pattern is intentional:
  - `print()` is the intended way this CLI script reports status to the Action log (`T201`).
  - The `subprocess` calls only ever shell out to the trusted `gh` CLI with constructed args (Dockerfile version string, hardcoded flags) — not external/untrusted input (`S603`/`S607`).
  - The manual `returncode` check on the label-fallback path is intentional, not an oversight (`PLW1510`).

## Test plan

- [x] `uv run ruff check .` — all checks pass
- [x] `uv run ruff format --check .` — all 14 files already formatted
- [x] `uv run pytest` — same 153 passed / 4 failed as `main` (the 4 failures are #658, fixed independently in #661; this branch doesn't include that fix)