### PR TITLE
fix: stop swallowing lint/test failures in CI, add ty gate

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -22,7 +22,6 @@ jobs:
         run: uv sync --all-groups
       - name: Lint with ruff
         id: ruff
-        continue-on-error: true
         run: |
           uv run ruff check . | tee lint.log
           ruff_check=${PIPESTATUS[0]}
@@ -33,9 +32,10 @@ jobs:
           cat lint.log >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
           exit $rescode
+      - name: Type check with ty
+        run: uv run ty check
       - name: Run pytest
         id: pytest
-        continue-on-error: true
         run: |
           uv run pytest | tee test.log
           rescode=${PIPESTATUS[0]}

--- a/fritzexporter/tr064_remote.py
+++ b/fritzexporter/tr064_remote.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from contextlib import contextmanager
+from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 from xml.etree.ElementTree import ParseError
 
@@ -40,12 +41,16 @@ class Tr064RemoteAccessSession(requests.Session):
     """
 
     def request(
-        self, method: str | bytes, url: str | bytes, *args: object, **kwargs: object
+        self,
+        method: str | bytes,
+        url: str | bytes,
+        *args: Any,  # noqa: ANN401
+        **kwargs: Any,  # noqa: ANN401
     ) -> requests.Response:
         if isinstance(url, bytes):
             url = url.decode()
         url = rewrite_tr064_remote_url(url)
-        return super().request(method, url, *args, **kwargs)  # type: ignore[arg-type]
+        return super().request(method, url, *args, **kwargs)
 
 
 @contextmanager
@@ -60,18 +65,18 @@ def remote_tr064_session(*, enabled: bool) -> Iterator[None]:
         return
 
     original_session = requests.Session
-    requests.Session = Tr064RemoteAccessSession  # type: ignore[misc,assignment]
+    requests.Session = Tr064RemoteAccessSession  # ty: ignore[invalid-assignment]
     try:
         yield
     finally:
-        requests.Session = original_session  # type: ignore[misc]
+        requests.Session = original_session
 
 
 @define(frozen=True)
 class ConnectionOptions:
     """TR-064 connection options shared by ``FritzDevice`` and ``create_fritz_connection``."""
 
-    connection_timeout: float | tuple[float, float] | None = None
+    connection_timeout: int | None = None
     use_tls: bool = False
     port: int | None = None
     remote_access: bool = False


### PR DESCRIPTION
## Summary

Closes #657.

`.github/workflows/run-tests.yaml` has had `continue-on-error: true` on both the `ruff` and `pytest` steps since 2021 (`b9f585e`), added as a side effect of wiring up a "comment test results on the PR" feature that was itself removed an hour later (`01f9b8c`) — the flag was never cleaned up and has silently prevented the "Run Unit Tests" check from ever failing on lint/test failures for ~5 years (see the archaeology in #657's comments).

This PR:
- Removes `continue-on-error: true` from both steps.
- Adds a new `ty check` step (no `[tool.ty]`-based CI gate existed before, despite `ty` already being a dev dependency and configured in `pyproject.toml`), also without `continue-on-error`.
- Makes the codebase actually **ty-clean first** (16 pre-existing diagnostics, all introduced by the WAN remote TR-064 work in #652/#659), so arming the new gate doesn't immediately turn CI red:
  - `ConnectionOptions.connection_timeout` was typed `float | tuple[float, float] | None`, but nothing anywhere produces/needs the tuple form, and `FritzConnection`'s own `timeout` param is `float | None` with no tuple support downstream either — narrowed to `int | None`, matching `DeviceConfig`/`OfflineDevice`.
  - `Tr064RemoteAccessSession.request`'s passthrough args were typed `object`, which can't satisfy `requests.Session.request`'s concrete stub signature when forwarded. Retyped as `Any` (justified: this method intentionally forwards arbitrary args to a third-party method it overrides) and dropped the dead `# type: ignore[arg-type]` comment — this project's ty config only honors `# ty: ignore[...]`, so the mypy-style comment was never actually suppressing anything.
  - The `requests.Session` monkeypatch assignment is a genuine `invalid-assignment` case ty can't represent safely; replaced the same kind of dead comment with a real `# ty: ignore[invalid-assignment]`, matching the suppression style already used in `config.py`.

**Note:** this branch is independent of #661 (fixes #658) and #662 (ruff format/lint cleanup) — its own CI run will still show those 4 pre-existing test failures and the `.github/scripts` lint issues, now for real since the gate is hard here. That's expected, not a regression in this PR; once all branches are merged (rebasing as needed), `main` will be clean under the hardened gate.

## Test plan

- [x] `uv run ty check` — all checks pass (was 16 diagnostics)
- [x] `uv run ruff check fritzexporter/` — all checks pass
- [x] Workflow YAML reviewed by hand for correctness (no CI run against this exact branch state possible pre-merge beyond GitHub Actions itself)