### PR TITLE
fix: reject explicitly-empty env config values instead of silently defaulting

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -40,7 +40,7 @@ If you only need a single device this is the easiest way to configure the export
 |                              | Only "true" or "1" will enable this feature.       |           |
 +------------------------------+----------------------------------------------------+-----------+
 | ``FRITZ_CONNECTION_TIMEOUT`` | Optional per-device TR-064 connect timeout in      |           |
-|                              | seconds. ``0`` or empty means no timeout.          |           |
+|                              | seconds. ``0`` or unset means no timeout.          |           |
 +------------------------------+----------------------------------------------------+-----------+
 | ``FRITZ_USE_TLS``            | Use HTTPS/TLS for TR-064 to the device.            | False     |
 |                              | Only ``true`` or ``1`` enable this. Certificate    |           |
@@ -50,7 +50,7 @@ If you only need a single device this is the easiest way to configure the export
 | ``FRITZ_DEVICE_PORT``        | Optional TR-064 port on the device. Defaults to    |           |
 |                              | ``49000`` (HTTP) or ``49443`` (TLS) via            |           |
 |                              | ``fritzconnection``. Distinct from ``FRITZ_PORT``  |           |
-|                              | (exporter listen port). ``0`` or empty = default.  |           |
+|                              | (exporter listen port). ``0`` or unset = default.  |           |
 +------------------------------+----------------------------------------------------+-----------+
 | ``FRITZ_REMOTE_ACCESS``      | Use AVM WAN remote TR-064 (``/tr064`` URL prefix). | False     |
 |                              | Requires ``FRITZ_USE_TLS=true``. Only ``true`` or  |           |

--- a/fritzexporter/config/config.py
+++ b/fritzexporter/config/config.py
@@ -85,11 +85,11 @@ def _read_config_from_env() -> dict:
     remote_access = os.getenv("FRITZ_REMOTE_ACCESS", "False")
 
     config: dict[Any, Any] = {}
-    if exporter_port:
+    if exporter_port is not None:
         config["exporter_port"] = exporter_port
-    if log_level:
+    if log_level is not None:
         config["log_level"] = log_level
-    if listen_address:
+    if listen_address is not None:
         config["listen_address"] = listen_address
 
     config["devices"] = []
@@ -105,7 +105,7 @@ def _read_config_from_env() -> dict:
         "port": device_port,
         "remote_access": remote_access,
     }
-    if hostname:
+    if hostname is not None:
         device["hostname"] = hostname
     config["devices"].append(device)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -222,6 +222,104 @@ class TestEnvConfig:
             get_config(None)
 
 
+class TestEnvEmptyVsUnsetValues:
+    """An explicitly-empty env var (VAR=) must fail validation, not silently
+    behave like an unset one falling back to the default."""
+
+    @pytest.fixture(autouse=True)
+    def _required_vars(self, monkeypatch):
+        monkeypatch.setenv("FRITZ_USERNAME", "SomeUserName")
+        monkeypatch.setenv("FRITZ_PASSWORD", "AnInterestingPassword")
+
+    def test_port_unset_uses_default(self, monkeypatch):
+        monkeypatch.delenv("FRITZ_PORT", raising=False)
+
+        config = get_config(None)
+
+        assert config.exporter_port == 9787
+
+    def test_port_empty_raises(self, monkeypatch):
+        monkeypatch.setenv("FRITZ_PORT", "")
+
+        with pytest.raises(ValueError, match="invalid literal for int"):
+            get_config(None)
+
+    def test_log_level_unset_uses_default(self, monkeypatch):
+        monkeypatch.delenv("FRITZ_LOG_LEVEL", raising=False)
+
+        config = get_config(None)
+
+        assert config.log_level == "INFO"
+
+    def test_log_level_empty_raises(self, monkeypatch):
+        monkeypatch.setenv("FRITZ_LOG_LEVEL", "")
+
+        with pytest.raises(ValueError, match="must be in"):
+            get_config(None)
+
+    def test_listen_address_unset_uses_default(self, monkeypatch):
+        monkeypatch.delenv("FRITZ_LISTEN_ADDRESS", raising=False)
+
+        config = get_config(None)
+
+        assert config.listen_address == "127.0.0.1"
+
+    def test_listen_address_empty_raises(self, monkeypatch):
+        monkeypatch.setenv("FRITZ_LISTEN_ADDRESS", "")
+
+        with pytest.raises(ValueError, match="does not appear to be"):
+            get_config(None)
+
+    def test_hostname_unset_uses_default(self, monkeypatch):
+        monkeypatch.delenv("FRITZ_HOSTNAME", raising=False)
+
+        config = get_config(None)
+
+        assert config.devices[0].hostname == "fritz.box"
+
+    def test_hostname_empty_raises(self, monkeypatch):
+        monkeypatch.setenv("FRITZ_HOSTNAME", "")
+
+        with pytest.raises(ValueError, match="Length of 'hostname'"):
+            get_config(None)
+
+    def test_connection_timeout_empty_raises(self, monkeypatch):
+        monkeypatch.setenv("FRITZ_CONNECTION_TIMEOUT", "")
+
+        with pytest.raises(ValueError, match="invalid literal for int"):
+            get_config(None)
+
+    def test_device_port_empty_raises(self, monkeypatch):
+        monkeypatch.setenv("FRITZ_DEVICE_PORT", "")
+
+        with pytest.raises(ValueError, match="invalid literal for int"):
+            get_config(None)
+
+    def test_host_info_empty_raises(self, monkeypatch):
+        monkeypatch.setenv("FRITZ_HOST_INFO", "")
+
+        with pytest.raises(ValueError, match="Cannot convert value to bool"):
+            get_config(None)
+
+    def test_wifi_client_info_empty_raises(self, monkeypatch):
+        monkeypatch.setenv("FRITZ_WIFI_CLIENT_INFO", "")
+
+        with pytest.raises(ValueError, match="Cannot convert value to bool"):
+            get_config(None)
+
+    def test_use_tls_empty_raises(self, monkeypatch):
+        monkeypatch.setenv("FRITZ_USE_TLS", "")
+
+        with pytest.raises(ValueError, match="Cannot convert value to bool"):
+            get_config(None)
+
+    def test_remote_access_empty_raises(self, monkeypatch):
+        monkeypatch.setenv("FRITZ_REMOTE_ACCESS", "")
+
+        with pytest.raises(ValueError, match="Cannot convert value to bool"):
+            get_config(None)
+
+
 class TestConfigEdgeCases:
     def test_bind_all_interfaces_logs_warning_for_ipv6(self, caplog):
         caplog.set_level(logging.WARNING)


### PR DESCRIPTION
## Summary

Closes #654.

`_read_config_from_env()` gated `exporter_port`, `log_level`, `listen_address` and `hostname` into the config dict with a truthiness check (`if x:`), which treats an explicitly-empty env var (`FRITZ_PORT=`, including one produced by faulty interpolation) identically to an unset one — silently falling back to the default instead of surfacing the bad input. Confirmed directly: `FRITZ_PORT= uv run python -c "..."` silently returned the default `9787` instead of raising.

All other env vars (`connection_timeout`, `port`, `host_info`, `wifi_client_info`, `use_tls`, `remote_access`, `username`, `password`) were already ungated and already correctly raise `ValueError` today via their attrs converters/validators (`int("")`, `to_bool("")`, `min_len(1)`) — verified directly, no change needed there.

Changes:
- `fritzexporter/config/config.py`: the four falsy-gated checks (`exporter_port`, `log_level`, `listen_address`, `hostname`) changed to `is not None`, letting an explicit empty string flow through to the existing validators, which already reject it correctly — no new validator code needed.
- `docs/configuration.rst`: reword the two "`0` or empty" mentions (`FRITZ_CONNECTION_TIMEOUT`, `FRITZ_DEVICE_PORT`) to "`0` or unset", matching the issue's requested wording and the now-consistent actual behavior.
- `tests/test_config.py`: new `TestEnvEmptyVsUnsetValues` class with regression coverage for unset (uses default) vs. explicit-empty (raises `ValueError`) across all affected env vars.

## Test plan

- [x] `uv run pytest` — 167 passed (153 existing + 14 new), same 4 pre-existing failures as `main` (#658, fixed independently in #661; this branch doesn't include that fix)
- [x] `uv run ruff check fritzexporter/` — all checks pass
- [x] Manually verified each previously-buggy var (`FRITZ_PORT=`, `FRITZ_LOG_LEVEL=`, `FRITZ_LISTEN_ADDRESS=`, `FRITZ_HOSTNAME=`) now raises `ValueError` when set empty, and still defaults correctly when unset