### PR TITLE
perf: collect home-automation metrics via a single AHA HTTP call

### DIFF
--- a/fritzexporter/fritz_aha.py
+++ b/fritzexporter/fritz_aha.py
@@ -1,27 +1,103 @@
+from typing import Any
 from xml.etree.ElementTree import Element
 
 from defusedxml import ElementTree
 
 
-def parse_aha_device_xml(deviceinfo: str) -> dict[str, str]:
+def _findtext(elem: Element, tag: str) -> str | None:
+    text = elem.findtext(tag)
+    return text.strip() if text is not None else None
+
+
+def _find_int(elem: Element, tag: str) -> int | None:
+    text = _findtext(elem, tag)
+    if text is None:
+        return None
     try:
-        device: Element = ElementTree.fromstring(deviceinfo)
+        return int(text)
+    except ValueError:
+        return None
 
-        battery_level = device.find("battery")
-        battery_low = device.find("batterylow")
 
-        result = {}
+def _parse_switch(device: Element) -> dict[str, Any] | None:
+    switch = device.find("switch")
+    if switch is None:
+        return None
+    return {
+        "state": _findtext(switch, "state"),
+        "mode": _findtext(switch, "mode"),
+        "lock": _findtext(switch, "lock"),
+    }
 
-        if battery_level is not None:
-            result["battery_level"] = battery_level.text or ""
 
-        if battery_low is not None:
-            result["battery_low"] = battery_low.text or ""
+def _parse_powermeter(device: Element) -> dict[str, Any] | None:
+    powermeter = device.find("powermeter")
+    if powermeter is None:
+        return None
+    return {
+        "power": _find_int(powermeter, "power"),
+        "energy": _find_int(powermeter, "energy"),
+    }
 
+
+def _parse_temperature(device: Element) -> dict[str, Any] | None:
+    temperature = device.find("temperature")
+    if temperature is None:
+        return None
+    return {
+        "celsius": _find_int(temperature, "celsius"),
+        "offset": _find_int(temperature, "offset"),
+    }
+
+
+def _parse_hkr(device: Element) -> dict[str, Any] | None:
+    hkr = device.find("hkr")
+    if hkr is None:
+        return None
+    return {
+        "tist": _find_int(hkr, "tist"),
+        "tsoll": _find_int(hkr, "tsoll"),
+        "absenk": _find_int(hkr, "absenk"),
+        "komfort": _find_int(hkr, "komfort"),
+        "battery_level": _find_int(hkr, "battery"),
+        "battery_low": _findtext(hkr, "batterylow"),
+    }
+
+
+def parse_aha_devicelist_xml(content: str) -> list[dict[str, Any]]:
+    try:
+        devicelist: Element = ElementTree.fromstring(content)
     except ElementTree.ParseError:
-        return {}
-    else:
-        return result
+        return []
+
+    devices = []
+    for device in devicelist.findall("device"):
+        hkr = _parse_hkr(device)
+        # On some firmware versions battery data is only reported nested
+        # inside <hkr> instead of as a direct child of <device>.
+        battery_level = _find_int(device, "battery")
+        battery_low = _findtext(device, "batterylow")
+        if battery_level is None and hkr is not None:
+            battery_level = hkr["battery_level"]
+            battery_low = hkr["battery_low"]
+
+        devices.append(
+            {
+                "ain": device.attrib.get("identifier", ""),
+                "device_id": device.attrib.get("id", ""),
+                "manufacturer": device.attrib.get("manufacturer", ""),
+                "productname": device.attrib.get("productname", ""),
+                "device_name": _findtext(device, "name") or "",
+                "present": _findtext(device, "present") == "1",
+                "battery_level": battery_level,
+                "battery_low": battery_low,
+                "switch": _parse_switch(device),
+                "powermeter": _parse_powermeter(device),
+                "temperature": _parse_temperature(device),
+                "hkr": hkr,
+            }
+        )
+    return devices
 
 
 # Copyright 2019-2026 Patrick Dreker <patrick@dreker.de>

--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -19,7 +19,7 @@ from fritzconnection.core.exceptions import (  # type: ignore[import]
 from fritzconnection.lib.fritzhosts import FritzHosts  # type: ignore[import]
 from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
 
-from fritzexporter.fritz_aha import parse_aha_device_xml
+from fritzexporter.fritz_aha import parse_aha_devicelist_xml
 
 if TYPE_CHECKING:
     from fritzexporter.fritzdevice import FritzDevice
@@ -1459,15 +1459,9 @@ class HomeAutomation(FritzCapability):
         "manufacturer",
         "productname",
     ]
-    _DEVICE_PRESENT_MAP: ClassVar[dict[str, int]] = {
-        "DISCONNECTED": 0,
-        "REGISTERED": 1,
-        "CONNECTED": 2,
-        "UNKNOWN": 3,
-    }
-    _SWITCH_MODE_MAP: ClassVar[dict[str, int]] = {"MANUAL": 0, "AUTO": 1, "UNDEFINED": 2}
-    _SWITCH_STATE_MAP: ClassVar[dict[str, int]] = {"OFF": 0, "ON": 1, "TOGGLE": 2, "UNDEFINED": 3}
     _HKR_VALVE_MAP: ClassVar[dict[str, int]] = {"CLOSED": 0, "OPEN": 1, "TEMP": 2}
+    _HTTP_SWITCH_STATE_MAP: ClassVar[dict[str | None, int]] = {"0": 0, "1": 1}
+    _HTTP_SWITCH_MODE_MAP: ClassVar[dict[str | None, int]] = {"manuell": 0, "auto": 1}
 
     def __init__(self) -> None:
         super().__init__()
@@ -1529,135 +1523,118 @@ class HomeAutomation(FritzCapability):
         for key, metric_name, help_text in metric_definitions:
             self.metrics[key] = GaugeMetricFamily(metric_name, help_text, labels=labels)
 
-    def _build_ha_labels(self, device: FritzDevice, ha_result: dict[str, Any]) -> list[str]:
+    def _build_ha_labels(self, device: FritzDevice, ha_device: dict[str, Any]) -> list[str]:
         return [
             device.serial,
             device.friendly_name,
-            ha_result["NewAIN"],
-            ha_result["NewDeviceName"],
-            str(ha_result["NewDeviceId"]),
-            ha_result["NewManufacturer"],
-            ha_result["NewProductName"],
+            ha_device["ain"],
+            ha_device["device_name"],
+            str(ha_device["device_id"]),
+            ha_device["manufacturer"],
+            ha_device["productname"],
         ]
 
-    def _collect_multimeter(self, ha_result: dict[str, Any], labels: list[str]) -> None:
-        if (
-            ha_result["NewMultimeterIsEnabled"] == "ENABLED"
-            and ha_result["NewMultimeterIsValid"] == "VALID"
-        ):
-            self.metrics["multimeter_power"].add_metric(
-                labels,
-                ha_result["NewMultimeterPower"] / 100.0,
-            )
-            self.metrics["multimeter_energy"].add_metric(labels, ha_result["NewMultimeterEnergy"])
+    def _collect_multimeter(self, ha_device: dict[str, Any], labels: list[str]) -> None:
+        powermeter = ha_device["powermeter"]
+        if powermeter is None:
+            return
+        if powermeter["power"] is not None:
+            self.metrics["multimeter_power"].add_metric(labels, powermeter["power"] / 1000.0)
+        if powermeter["energy"] is not None:
+            self.metrics["multimeter_energy"].add_metric(labels, powermeter["energy"])
 
-    def _collect_temperature(self, ha_result: dict[str, Any], labels: list[str]) -> None:
-        if (
-            ha_result["NewTemperatureIsEnabled"] == "ENABLED"
-            and ha_result["NewTemperatureIsValid"] == "VALID"
-        ):
-            self.metrics["temperature"].add_metric(
-                labels,
-                ha_result["NewTemperatureCelsius"] / 10.0,
-            )
-            self.metrics["temperature_offset"].add_metric(
-                labels,
-                ha_result["NewTemperatureOffset"] / 10.0,
-            )
+    def _collect_temperature(self, ha_device: dict[str, Any], labels: list[str]) -> None:
+        temperature = ha_device["temperature"]
+        if temperature is None:
+            return
+        if temperature["celsius"] is not None:
+            self.metrics["temperature"].add_metric(labels, temperature["celsius"] / 10.0)
+        if temperature["offset"] is not None:
+            self.metrics["temperature_offset"].add_metric(labels, temperature["offset"] / 10.0)
 
-    def _collect_switch(self, ha_result: dict[str, Any], labels: list[str]) -> None:
-        if (
-            ha_result["NewSwitchIsEnabled"] == "ENABLED"
-            and ha_result["NewSwitchIsValid"] == "VALID"
-        ):
+    def _collect_switch(self, ha_device: dict[str, Any], labels: list[str]) -> None:
+        switch = ha_device["switch"]
+        if switch is None:
+            return
+        if switch["state"] in self._HTTP_SWITCH_STATE_MAP:
             self.metrics["switch_state"].add_metric(
-                labels,
-                self._SWITCH_STATE_MAP[ha_result["NewSwitchState"]],
+                labels, self._HTTP_SWITCH_STATE_MAP[switch["state"]]
             )
+        if switch["mode"] in self._HTTP_SWITCH_MODE_MAP:
             self.metrics["switch_mode"].add_metric(
-                labels,
-                self._SWITCH_MODE_MAP[ha_result["NewSwitchMode"]],
+                labels, self._HTTP_SWITCH_MODE_MAP[switch["mode"]]
             )
-            self.metrics["switch_lock"].add_metric(
-                labels,
-                1 if ha_result["NewSwitchLock"] else 0,
-            )
+        if switch["lock"] is not None:
+            self.metrics["switch_lock"].add_metric(labels, 1 if switch["lock"] == "1" else 0)
 
-    def _collect_heater(self, ha_result: dict[str, Any], labels: list[str]) -> None:
-        if ha_result["NewHkrIsEnabled"] == "ENABLED" and ha_result["NewHkrIsValid"] == "VALID":
-            self.metrics["heater_temperature"].add_metric(
-                labels,
-                ha_result["NewHkrIsTemperature"] / 10.0,
-            )
-            self.metrics["heater_set_temperature"].add_metric(
-                labels,
-                ha_result["NewHkrSetTemperature"] / 10.0,
-            )
-            self.metrics["heater_valve_set_state"].add_metric(
-                labels,
-                self._HKR_VALVE_MAP[ha_result["NewHkrSetVentilStatus"]],
-            )
-            self.metrics["heater_reduced_temperature"].add_metric(
-                labels,
-                ha_result["NewHkrReduceTemperature"] / 10.0,
-            )
-            self.metrics["heater_comfort_temperature"].add_metric(
-                labels,
-                ha_result["NewHkrComfortTemperature"] / 10.0,
-            )
-            self.metrics["heater_reduced_valve_state"].add_metric(
-                labels,
-                self._HKR_VALVE_MAP[ha_result["NewHkrReduceVentilStatus"]],
-            )
-            self.metrics["heater_comfort_valve_state"].add_metric(
-                labels,
-                self._HKR_VALVE_MAP[ha_result["NewHkrComfortVentilStatus"]],
-            )
+    def _collect_heater(self, ha_device: dict[str, Any], labels: list[str]) -> None:
+        hkr = ha_device["hkr"]
+        if hkr is None:
+            return
+        # HKR temperatures from the AHA HTTP API are reported in half-degree
+        # steps, unlike the plain <temperature> element (tenths of a degree).
+        if hkr["tist"] is not None:
+            self.metrics["heater_temperature"].add_metric(labels, hkr["tist"] / 2.0)
+        if hkr["tsoll"] is not None:
+            self.metrics["heater_set_temperature"].add_metric(labels, hkr["tsoll"] / 2.0)
+        if hkr["absenk"] is not None:
+            self.metrics["heater_reduced_temperature"].add_metric(labels, hkr["absenk"] / 2.0)
+        if hkr["komfort"] is not None:
+            self.metrics["heater_comfort_temperature"].add_metric(labels, hkr["komfort"] / 2.0)
 
-    def _collect_battery(self, device: FritzDevice, ain: str, labels: list[str]) -> None:
-        # Battery data comes from the AHA HTTP API, not TR-064.
-        # "battery" XML element maps to "battery_level".
+    def _collect_heater_valve_state(self, device: FritzDevice, ain: str, labels: list[str]) -> None:
+        # The valve/ventil status fields are not exposed by the AHA HTTP API's
+        # getdevicelistinfos response, so they still require one TR-064 call
+        # per thermostat (identified by AIN, not by enumeration index).
         try:
-            http_result = device.fc.call_http("getdeviceinfos", ain)
-        except FritzHttpInterfaceError:
-            logger.debug("Got FritzHttpInterfaceError for ain %s, skipping", ain)
+            ha_result = device.fc.call_action(
+                "X_AVM-DE_Homeauto1", "GetSpecificDeviceInfos", NewAIN=ain
+            )
+        except FritzArgumentError, FritzActionError, FritzArrayIndexError:
+            logger.debug("Could not fetch HKR valve state for ain %s, skipping", ain)
             return
-        if "content" not in http_result:
-            return
-        http_data = parse_aha_device_xml(http_result["content"])
-        if "battery_level" in http_data:
-            self.metrics["battery_level"].add_metric(labels, float(http_data["battery_level"]))
-        if "battery_low" in http_data:
+
+        if "NewHkrSetVentilStatus" in ha_result:
+            self.metrics["heater_valve_set_state"].add_metric(
+                labels, self._HKR_VALVE_MAP[ha_result["NewHkrSetVentilStatus"]]
+            )
+        if "NewHkrReduceVentilStatus" in ha_result:
+            self.metrics["heater_reduced_valve_state"].add_metric(
+                labels, self._HKR_VALVE_MAP[ha_result["NewHkrReduceVentilStatus"]]
+            )
+        if "NewHkrComfortVentilStatus" in ha_result:
+            self.metrics["heater_comfort_valve_state"].add_metric(
+                labels, self._HKR_VALVE_MAP[ha_result["NewHkrComfortVentilStatus"]]
+            )
+
+    def _collect_battery(self, ha_device: dict[str, Any], labels: list[str]) -> None:
+        if ha_device["battery_level"] is not None:
+            self.metrics["battery_level"].add_metric(labels, float(ha_device["battery_level"]))
+        if ha_device["battery_low"] is not None:
             self.metrics["battery_low"].add_metric(
-                labels,
-                1 if http_data["battery_low"] == "1" else 0,
+                labels, 1 if ha_device["battery_low"] == "1" else 0
             )
 
     def _generate_metric_values(self, device: FritzDevice) -> None:
-        index = 0
-        while True:
-            logger.debug("Fetching home automation device information for index %d", index)
-            try:
-                ha_result = device.fc.call_action(
-                    "X_AVM-DE_Homeauto1", "GetGenericDeviceInfos", NewIndex=index
-                )
-            except FritzArrayIndexError:
-                logger.debug("Got IndexError for index %d, stopping", index)
-                break
+        try:
+            http_result = device.fc.call_http("getdevicelistinfos")
+        except FritzHttpInterfaceError:
+            logger.debug("Got FritzHttpInterfaceError for device %s, skipping", device.host)
+            return
+        if "content" not in http_result:
+            return
 
-            ain = ha_result["NewAIN"]
-            labels = self._build_ha_labels(device, ha_result)
+        for ha_device in parse_aha_devicelist_xml(http_result["content"]):
+            labels = self._build_ha_labels(device, ha_device)
 
-            self.metrics["devicepresent"].add_metric(
-                labels,
-                self._DEVICE_PRESENT_MAP[ha_result["NewPresent"]],
-            )
-            self._collect_multimeter(ha_result, labels)
-            self._collect_temperature(ha_result, labels)
-            self._collect_switch(ha_result, labels)
-            self._collect_heater(ha_result, labels)
-            index += 1
-            self._collect_battery(device, ain, labels)
+            self.metrics["devicepresent"].add_metric(labels, 2 if ha_device["present"] else 0)
+            self._collect_multimeter(ha_device, labels)
+            self._collect_temperature(ha_device, labels)
+            self._collect_switch(ha_device, labels)
+            self._collect_heater(ha_device, labels)
+            self._collect_battery(ha_device, labels)
+            if ha_device["hkr"] is not None:
+                self._collect_heater_valve_state(device, ha_device["ain"], labels)
 
     def _get_metric_values(
         self,

--- a/tests/fc_services_mock.py
+++ b/tests/fc_services_mock.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 from fritzconnection.core.exceptions import (
     FritzActionError,
     FritzServiceError,
-    FritzArrayIndexError,
 )
 
 
@@ -18,18 +17,18 @@ def create_fc_services(services_mock):
         services[svc] = FCService(actions)
     return services
 
-def call_http_mock(action, ain, **_):
+def call_http_mock(action, ain=None, **_):
     return {
         "content": """<?xml version="1.0" encoding="utf-8"?>
-        <device>
+        <devicelist version="1">
+        <device identifier="123456789012" id="123" functionbitmask="1"
+                fwversion="1.2" manufacturer="AVM" productname="MockDevice">
             <present>1</present>
             <name>Fritz!DECT 200</name>
-            <manufacturer>AVM</manufacturer>
-            <manufacturerURL>http://www.avm.de</manufacturerURL>
-            <model>Fritz!DECT 200</model>
             <battery>100</battery>
             <batterylow>0</batterylow>
-        </device>""",
+        </device>
+        </devicelist>""",
         "content-type": "text/xml",
         "encoding": "utf-8"
     }
@@ -192,45 +191,14 @@ def call_action_mock(service, action, **kwargs):
             "MaxCharsDeviceName": 32,
             "MinCharsDeviceName": 10,
         },
-        ("X_AVM-DE_Homeauto1", "GetGenericDeviceInfos"): {
+        ("X_AVM-DE_Homeauto1", "GetSpecificDeviceInfos"): {
             "NewAIN": "123456789012",
-            "NewDeviceId": 123,
-            "NewFunctionBitMask": 1,
-            "NewFirmwareVersion": "1.2",
-            "NewManufacturer": "AVM",
-            "NewProductName": "MockDevice",
-            "NewDeviceName": "MockDeviceName",
-            "NewPresent": "CONNECTED",
-            "NewMultimeterIsEnabled": "ENABLED",
-            "NewMultimeterIsValid": "VALID",
-            "NewMultimeterPower": 1234,
-            "NewMultimeterEnergy": 12345,
-            "NewTemperatureIsEnabled": "ENABLED",
-            "NewTemperatureIsValid": "VALID",
-            "NewTemperatureCelsius": 234,
-            "NewTemperatureOffset": 0,
-            "NewSwitchIsEnabled": "ENABLED",
-            "NewSwitchIsValid": "VALID",
-            "NewSwitchState": "ON",
-            "NewSwitchMode": "MANUAL",
-            "NewSwitchLock": False,
-            "NewHkrIsEnabled": "ENABLED",
-            "NewHkrIsValid": "VALID",
-            "NewHkrIsTemperature": 245,
             "NewHkrSetVentilStatus": "OPEN",
-            "NewHkrSetTemperature": 234,
             "NewHkrReduceVentilStatus": "CLOSED",
-            "NewHkrReduceTemperature": 234,
             "NewHkrComfortVentilStatus": "OPEN",
-            "NewHkrComfortTemperature": 234,
         },
     }
 
-    if service == "X_AVM-DE_Homeauto1" and action == "GetGenericDeviceInfos":
-        if kwargs["NewIndex"] == 0:
-            return call_action_responses[(service, action)]
-        else:
-            raise FritzArrayIndexError
     if (service, action) not in call_action_responses:
         raise FritzServiceError(f"Unknown service/action: {service}/{action}")
     return call_action_responses[(service, action)]
@@ -376,37 +344,11 @@ def call_action_no_basic_mock(service, action, **_):
             "NewX_AVM-DE_Model": "Mockgear",
             "NewX_AVM-DE_Speed": 1000,
         },
-        ("X_AVM-DE_Homeauto1", "GetGenericDeviceInfos"): {
+        ("X_AVM-DE_Homeauto1", "GetSpecificDeviceInfos"): {
             "NewAIN": "123456789012",
-            "NewDeviceId": 123,
-            "NewFunctionBitMask": 1,
-            "NewFirmwareVersion": "1.2",
-            "NewManufacturer": "AVM",
-            "NewProductName": "MockDevice",
-            "NewDeviceName": "MockDeviceName",
-            "NewPresent": "CONNECTED",
-            "NewMultimeterIsEnabled": "ENABLED",
-            "NewMultimeterIsValid": "VALID",
-            "NewMultimeterPower": 1234,
-            "NewMultimeterEnergy": 12345,
-            "NewTemperatureIsEnabled": "ENABLED",
-            "NewTemperatureIsValid": "VALID",
-            "NewTemperatureCelsius": 234,
-            "NewTemperatureOffset": 0,
-            "NewSwitchIsEnabled": "ENABLED",
-            "NewSwitchIsValid": "VALID",
-            "NewSwitchState": "ON",
-            "NewSwitchMode": "MANUAL",
-            "NewSwitchLock": False,
-            "NewHkrIsEnabled": "ENABLED",
-            "NewHkrIsValid": "VALID",
-            "NewHkrIsTemperature": 245,
             "NewHkrSetVentilStatus": "OPEN",
-            "NewHkrSetTemperature": 234,
             "NewHkrReduceVentilStatus": "CLOSED",
-            "NewHkrReduceTemperature": 234,
             "NewHkrComfortVentilStatus": "OPEN",
-            "NewHkrComfortTemperature": 234,
         },
     }
 
@@ -554,37 +496,11 @@ def call_action_no_basic_action_error_mock(service, action, **kwargs):
             "NewX_AVM-DE_Model": "Mockgear",
             "NewX_AVM-DE_Speed": 1000,
         },
-        ("X_AVM-DE_Homeauto1", "GetGenericDeviceInfos"): {
+        ("X_AVM-DE_Homeauto1", "GetSpecificDeviceInfos"): {
             "NewAIN": "123456789012",
-            "NewDeviceId": 123,
-            "NewFunctionBitMask": 1,
-            "NewFirmwareVersion": "1.2",
-            "NewManufacturer": "AVM",
-            "NewProductName": "MockDevice",
-            "NewDeviceName": "MockDeviceName",
-            "NewPresent": "CONNECTED",
-            "NewMultimeterIsEnabled": "ENABLED",
-            "NewMultimeterIsValid": "VALID",
-            "NewMultimeterPower": 1234,
-            "NewMultimeterEnergy": 12345,
-            "NewTemperatureIsEnabled": "ENABLED",
-            "NewTemperatureIsValid": "VALID",
-            "NewTemperatureCelsius": 234,
-            "NewTemperatureOffset": 0,
-            "NewSwitchIsEnabled": "ENABLED",
-            "NewSwitchIsValid": "VALID",
-            "NewSwitchState": "ON",
-            "NewSwitchMode": "MANUAL",
-            "NewSwitchLock": False,
-            "NewHkrIsEnabled": "ENABLED",
-            "NewHkrIsValid": "VALID",
-            "NewHkrIsTemperature": 245,
             "NewHkrSetVentilStatus": "OPEN",
-            "NewHkrSetTemperature": 234,
             "NewHkrReduceVentilStatus": "CLOSED",
-            "NewHkrReduceTemperature": 234,
             "NewHkrComfortVentilStatus": "OPEN",
-            "NewHkrComfortTemperature": 234,
         },
     }
 
@@ -812,7 +728,7 @@ fc_services_capabilities["HostInfo"] = {
 fc_services_capabilities["HomeAutomation"] = {
     "X_AVM-DE_Homeauto1": [
         "GetInfo",
-        "GetGenericDeviceInfos",
+        "GetSpecificDeviceInfos",
     ],
 }
 

--- a/tests/test_fritzcapabilities.py
+++ b/tests/test_fritzcapabilities.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fritzconnection.core.exceptions import (
     FritzActionError,
+    FritzArgumentError,
     FritzArrayIndexError,
     FritzHttpInterfaceError,
     FritzServiceError,
@@ -242,62 +243,52 @@ class TestHostInfoCapability:
 class TestHomeAutomationCapability:
     """Tests for HomeAutomation capability edge cases."""
 
-    def _make_ha_response(
+    def _make_device_xml(
         self,
-        multimeter_enabled=True,
-        multimeter_valid=True,
-        temperature_enabled=True,
-        temperature_valid=True,
-        switch_enabled=True,
-        switch_valid=True,
-        hkr_enabled=True,
-        hkr_valid=True,
-    ) -> dict:
-        return {
-            "NewAIN": "123456789012",
-            "NewDeviceId": 123,
-            "NewFunctionBitMask": 1,
-            "NewFirmwareVersion": "1.2",
-            "NewManufacturer": "AVM",
-            "NewProductName": "MockDevice",
-            "NewDeviceName": "MockDeviceName",
-            "NewPresent": "CONNECTED",
-            "NewMultimeterIsEnabled": "ENABLED" if multimeter_enabled else "DISABLED",
-            "NewMultimeterIsValid": "VALID" if multimeter_valid else "INVALID",
-            "NewMultimeterPower": 1234,
-            "NewMultimeterEnergy": 12345,
-            "NewTemperatureIsEnabled": "ENABLED" if temperature_enabled else "DISABLED",
-            "NewTemperatureIsValid": "VALID" if temperature_valid else "INVALID",
-            "NewTemperatureCelsius": 234,
-            "NewTemperatureOffset": 0,
-            "NewSwitchIsEnabled": "ENABLED" if switch_enabled else "DISABLED",
-            "NewSwitchIsValid": "VALID" if switch_valid else "INVALID",
-            "NewSwitchState": "ON",
-            "NewSwitchMode": "MANUAL",
-            "NewSwitchLock": False,
-            "NewHkrIsEnabled": "ENABLED" if hkr_enabled else "DISABLED",
-            "NewHkrIsValid": "VALID" if hkr_valid else "INVALID",
-            "NewHkrIsTemperature": 245,
-            "NewHkrSetVentilStatus": "OPEN",
-            "NewHkrSetTemperature": 234,
-            "NewHkrReduceVentilStatus": "CLOSED",
-            "NewHkrReduceTemperature": 234,
-            "NewHkrComfortVentilStatus": "OPEN",
-            "NewHkrComfortTemperature": 234,
-        }
+        ain="123456789012",
+        include_powermeter=True,
+        include_temperature=True,
+        include_switch=True,
+        include_hkr=True,
+        battery: str | None = "100",
+        batterylow: str | None = "0",
+    ) -> str:
+        parts = [
+            f'<device identifier="{ain}" id="123" functionbitmask="1" '
+            'fwversion="1.2" manufacturer="AVM" productname="MockDevice">',
+            "<present>1</present>",
+            "<name>MockDeviceName</name>",
+        ]
+        if battery is not None:
+            parts.append(f"<battery>{battery}</battery>")
+        if batterylow is not None:
+            parts.append(f"<batterylow>{batterylow}</batterylow>")
+        if include_powermeter:
+            parts.append("<powermeter><power>1234</power><energy>12345</energy></powermeter>")
+        if include_temperature:
+            parts.append("<temperature><celsius>234</celsius><offset>0</offset></temperature>")
+        if include_switch:
+            parts.append("<switch><state>1</state><mode>manuell</mode><lock>0</lock></switch>")
+        if include_hkr:
+            parts.append(
+                "<hkr><tist>245</tist><tsoll>234</tsoll><absenk>234</absenk>"
+                "<komfort>234</komfort></hkr>"
+            )
+        parts.append("</device>")
+        return "".join(parts)
 
-    def _setup_ha_device(self, mock_fc, ha_response: dict) -> tuple:
+    def _make_devicelist_xml(self, *device_xml: str) -> str:
+        return f'<devicelist version="1">{"".join(device_xml)}</devicelist>'
+
+    def _setup_ha_device(self, mock_fc, devicelist_xml: str) -> tuple:
         fc = mock_fc.return_value
 
-        def ha_mock(service, action, **kwargs):
-            if service == "X_AVM-DE_Homeauto1" and action == "GetGenericDeviceInfos":
-                if kwargs.get("NewIndex", 0) == 0:
-                    return ha_response
-                raise FritzArrayIndexError
-            return call_action_mock(service, action, **kwargs)
-
-        fc.call_action.side_effect = ha_mock
-        fc.call_http.side_effect = call_http_mock
+        fc.call_action.side_effect = call_action_mock
+        fc.call_http.side_effect = lambda action, ain=None, **kw: {
+            "content": devicelist_xml,
+            "content-type": "text/xml",
+            "encoding": "utf-8",
+        }
         fc.services = create_fc_services(fc_services_capabilities["HomeAutomation"])
 
         collector = FritzCollector()
@@ -307,21 +298,8 @@ class TestHomeAutomationCapability:
 
     def test_homeautomation_with_disabled_multimeter(self, mock_fritzconnection: MagicMock):
         # Prepare
-        ha_response = self._make_ha_response(multimeter_enabled=False)
-        collector, device, _ = self._setup_ha_device(mock_fritzconnection, ha_response)
-
-        # Act
-        metrics: list[Metric] = list(collector.collect())
-
-        # Check - multimeter metrics should have no samples
-        power_metrics = [m for m in metrics if m.name == "fritz_ha_multimeter_power_W"]
-        assert len(power_metrics) == 1
-        assert len(power_metrics[0].samples) == 0
-
-    def test_homeautomation_with_invalid_multimeter(self, mock_fritzconnection: MagicMock):
-        # Prepare
-        ha_response = self._make_ha_response(multimeter_valid=False)
-        collector, device, _ = self._setup_ha_device(mock_fritzconnection, ha_response)
+        xml = self._make_devicelist_xml(self._make_device_xml(include_powermeter=False))
+        collector, device, _ = self._setup_ha_device(mock_fritzconnection, xml)
 
         # Act
         metrics: list[Metric] = list(collector.collect())
@@ -333,8 +311,8 @@ class TestHomeAutomationCapability:
 
     def test_homeautomation_with_disabled_temperature(self, mock_fritzconnection: MagicMock):
         # Prepare
-        ha_response = self._make_ha_response(temperature_enabled=False)
-        collector, device, _ = self._setup_ha_device(mock_fritzconnection, ha_response)
+        xml = self._make_devicelist_xml(self._make_device_xml(include_temperature=False))
+        collector, device, _ = self._setup_ha_device(mock_fritzconnection, xml)
 
         # Act
         metrics: list[Metric] = list(collector.collect())
@@ -346,8 +324,8 @@ class TestHomeAutomationCapability:
 
     def test_homeautomation_with_disabled_switch(self, mock_fritzconnection: MagicMock):
         # Prepare
-        ha_response = self._make_ha_response(switch_enabled=False)
-        collector, device, _ = self._setup_ha_device(mock_fritzconnection, ha_response)
+        xml = self._make_devicelist_xml(self._make_device_xml(include_switch=False))
+        collector, device, _ = self._setup_ha_device(mock_fritzconnection, xml)
 
         # Act
         metrics: list[Metric] = list(collector.collect())
@@ -359,8 +337,8 @@ class TestHomeAutomationCapability:
 
     def test_homeautomation_with_disabled_heater(self, mock_fritzconnection: MagicMock):
         # Prepare
-        ha_response = self._make_ha_response(hkr_enabled=False)
-        collector, device, _ = self._setup_ha_device(mock_fritzconnection, ha_response)
+        xml = self._make_devicelist_xml(self._make_device_xml(include_hkr=False))
+        collector, device, _ = self._setup_ha_device(mock_fritzconnection, xml)
 
         # Act
         metrics: list[Metric] = list(collector.collect())
@@ -370,11 +348,82 @@ class TestHomeAutomationCapability:
         assert len(heater_metrics) == 1
         assert len(heater_metrics[0].samples) == 0
 
+        # No hkr block means no need to fetch valve state via TR-064
+        valve_metrics = [m for m in metrics if m.name == "fritz_ha_heater_valve_set_state"]
+        assert len(valve_metrics) == 1
+        assert len(valve_metrics[0].samples) == 0
+
+    def test_homeautomation_heater_includes_valve_state(self, mock_fritzconnection: MagicMock):
+        # Prepare - a device with an hkr block should also get its valve
+        # state via a supplemental TR-064 GetSpecificDeviceInfos call.
+        xml = self._make_devicelist_xml(self._make_device_xml())
+        collector, device, _ = self._setup_ha_device(mock_fritzconnection, xml)
+
+        # Act
+        metrics: list[Metric] = list(collector.collect())
+
+        # Check
+        heater_temp = [m for m in metrics if m.name == "fritz_ha_heater_temperature_C"]
+        assert heater_temp[0].samples[0].value == 245 / 2.0
+
+        valve_set = [m for m in metrics if m.name == "fritz_ha_heater_valve_set_state"]
+        assert len(valve_set[0].samples) == 1
+        assert valve_set[0].samples[0].value == 1  # OPEN
+
+    def test_homeautomation_valve_state_lookup_failure_is_skipped(
+        self, mock_fritzconnection: MagicMock, caplog
+    ):
+        # Prepare - GetSpecificDeviceInfos can fail for a device (e.g. it
+        # disappeared between the two calls); the heater temperatures from
+        # the bulk HTTP call should still be reported.
+        caplog.set_level(logging.DEBUG)
+        xml = self._make_devicelist_xml(self._make_device_xml())
+        collector, device, fc = self._setup_ha_device(mock_fritzconnection, xml)
+
+        def failing_action(service, action, **kwargs):
+            if service == "X_AVM-DE_Homeauto1" and action == "GetSpecificDeviceInfos":
+                raise FritzArgumentError("unknown ain")
+            return call_action_mock(service, action, **kwargs)
+
+        fc.call_action.side_effect = failing_action
+
+        # Act
+        metrics: list[Metric] = list(collector.collect())
+
+        # Check
+        heater_temp = [m for m in metrics if m.name == "fritz_ha_heater_temperature_C"]
+        assert len(heater_temp[0].samples) == 1
+
+        valve_set = [m for m in metrics if m.name == "fritz_ha_heater_valve_set_state"]
+        assert len(valve_set[0].samples) == 0
+
+        assert any(
+            "Could not fetch HKR valve state" in record.message for record in caplog.records
+        )
+
+    def test_homeautomation_multiple_devices_in_one_response(self, mock_fritzconnection: MagicMock):
+        # Prepare - two devices returned from a single getdevicelistinfos call
+        xml = self._make_devicelist_xml(
+            self._make_device_xml(ain="111111111111", include_hkr=False),
+            self._make_device_xml(ain="222222222222", include_hkr=False),
+        )
+        collector, device, _ = self._setup_ha_device(mock_fritzconnection, xml)
+
+        # Act
+        metrics: list[Metric] = list(collector.collect())
+
+        # Check - both devices show up as separate label sets
+        device_present = [m for m in metrics if m.name == "fritz_ha_device_present"]
+        assert len(device_present) == 1
+        assert len(device_present[0].samples) == 2
+        ains = {s.labels["ain"] for s in device_present[0].samples}
+        assert ains == {"111111111111", "222222222222"}
+
     def test_homeautomation_with_fritz_http_interface_error(self, mock_fritzconnection: MagicMock, caplog):
         # Prepare
         caplog.set_level(logging.DEBUG)
-        ha_response = self._make_ha_response()
-        collector, device, fc = self._setup_ha_device(mock_fritzconnection, ha_response)
+        xml = self._make_devicelist_xml(self._make_device_xml())
+        collector, device, fc = self._setup_ha_device(mock_fritzconnection, xml)
 
         # Make call_http raise FritzHttpInterfaceError
         fc.call_http.side_effect = FritzHttpInterfaceError("HTTP interface error")
@@ -382,14 +431,11 @@ class TestHomeAutomationCapability:
         # Act
         metrics: list[Metric] = list(collector.collect())
 
-        # Check - should still produce device present metric, no battery metrics
+        # Check - the whole device list comes from this one call, so on
+        # failure no home automation devices are reported at all.
         device_present = [m for m in metrics if m.name == "fritz_ha_device_present"]
         assert len(device_present) == 1
-        assert len(device_present[0].samples) == 1
-
-        battery_metrics = [m for m in metrics if m.name == "fritz_ha_battery_level_percent"]
-        assert len(battery_metrics) == 1
-        assert len(battery_metrics[0].samples) == 0
+        assert len(device_present[0].samples) == 0
 
         # Warning should be logged
         assert any(
@@ -399,36 +445,26 @@ class TestHomeAutomationCapability:
 
     def test_homeautomation_no_content_in_http_result(self, mock_fritzconnection: MagicMock):
         # Prepare
-        ha_response = self._make_ha_response()
-        collector, device, fc = self._setup_ha_device(mock_fritzconnection, ha_response)
+        xml = self._make_devicelist_xml(self._make_device_xml())
+        collector, device, fc = self._setup_ha_device(mock_fritzconnection, xml)
 
         # Make call_http return a response without 'content'
-        fc.call_http.side_effect = lambda action, ain, **kw: {"status": "ok"}
+        fc.call_http.side_effect = lambda action, ain=None, **kw: {"status": "ok"}
 
         # Act
         metrics: list[Metric] = list(collector.collect())
 
-        # Check - battery metrics should have no samples since no content
-        battery_metrics = [m for m in metrics if m.name == "fritz_ha_battery_level_percent"]
-        assert len(battery_metrics) == 1
-        assert len(battery_metrics[0].samples) == 0
+        # Check - no devices at all since there is no content to parse
+        device_present = [m for m in metrics if m.name == "fritz_ha_device_present"]
+        assert len(device_present) == 1
+        assert len(device_present[0].samples) == 0
 
     def test_homeautomation_no_battery_low_in_http_data(self, mock_fritzconnection: MagicMock):
-        # Prepare - return XML without batterylow element
-        ha_response = self._make_ha_response()
-        collector, device, fc = self._setup_ha_device(mock_fritzconnection, ha_response)
-
-        # Make call_http return XML without batterylow
-        fc.call_http.side_effect = lambda action, ain, **kw: {
-            "content": """<?xml version="1.0" encoding="utf-8"?>
-            <device>
-                <present>1</present>
-                <name>Fritz!DECT 200</name>
-                <battery>75</battery>
-            </device>""",
-            "content-type": "text/xml",
-            "encoding": "utf-8",
-        }
+        # Prepare - device XML without batterylow element
+        xml = self._make_devicelist_xml(
+            self._make_device_xml(battery="75", batterylow=None, include_hkr=False)
+        )
+        collector, device, fc = self._setup_ha_device(mock_fritzconnection, xml)
 
         # Act
         metrics: list[Metric] = list(collector.collect())
@@ -444,19 +480,11 @@ class TestHomeAutomationCapability:
         assert len(battery_low[0].samples) == 0
 
     def test_homeautomation_no_battery_in_xml(self, mock_fritzconnection: MagicMock):
-        # Prepare - return XML without battery element (but has content)
-        ha_response = self._make_ha_response()
-        collector, device, fc = self._setup_ha_device(mock_fritzconnection, ha_response)
-
-        fc.call_http.side_effect = lambda action, ain, **kw: {
-            "content": """<?xml version="1.0" encoding="utf-8"?>
-            <device>
-                <present>1</present>
-                <name>Fritz!DECT 200</name>
-            </device>""",
-            "content-type": "text/xml",
-            "encoding": "utf-8",
-        }
+        # Prepare - device XML without battery element (but has content)
+        xml = self._make_devicelist_xml(
+            self._make_device_xml(battery=None, batterylow=None, include_hkr=False)
+        )
+        collector, device, fc = self._setup_ha_device(mock_fritzconnection, xml)
 
         # Act
         metrics: list[Metric] = list(collector.collect())

--- a/tests/test_fritzdevice.py
+++ b/tests/test_fritzdevice.py
@@ -13,7 +13,7 @@ from prometheus_client.core import Metric
 
 from fritzexporter.exceptions import FritzDeviceHasNoCapabilitiesError
 from fritzexporter.fritzdevice import FritzCollector, FritzCredentials, FritzDevice
-from fritzexporter.fritz_aha import parse_aha_device_xml
+from fritzexporter.fritz_aha import parse_aha_devicelist_xml
 from fritzexporter.tr064_remote import ConnectionOptions
 
 from .fc_services_mock import (
@@ -199,36 +199,35 @@ class TestFritzDevice:
     def test_should_correctly_parse_aha_xml(self, mock_fritzconnection: MagicMock, caplog):
         # Prepare
         deviceinfo = """<?xml version="1.0" encoding="utf-8"?>
-        <device>
+        <devicelist version="1">
+        <device identifier="123456789012" id="123" functionbitmask="1"
+                fwversion="1.2" manufacturer="AVM" productname="Fritz!DECT 200">
             <present>1</present>
-            <name>Fritz!DECT 200
-            </name>
-            <manufacturer>AVM</manufacturer>
-            <manufacturerURL>http://www.avm.de</manufacturerURL>
-            <model>Fritz!DECT 200</model>
+            <name>Fritz!DECT 200</name>
             <battery>100</battery>
             <batterylow>0</batterylow>
         </device>
+        </devicelist>
         """
         # Act
-        device_data = parse_aha_device_xml(deviceinfo)
+        devices = parse_aha_devicelist_xml(deviceinfo)
 
         # Check
-        assert device_data["battery_level"] == "100"
-        assert device_data["battery_low"] == "0"
+        assert len(devices) == 1
+        assert devices[0]["battery_level"] == 100
+        assert devices[0]["battery_low"] == "0"
 
     def test_should_correctly_parse_aha_xml_when_empty(self, mock_fritzconnection: MagicMock, caplog):
         # Prepare
         deviceinfo = """<?xml version="1.0" encoding="utf-8"?>
-        <device>
-        </device>
+        <devicelist version="1">
+        </devicelist>
         """
         # Act
-        device_data = parse_aha_device_xml(deviceinfo)
+        devices = parse_aha_devicelist_xml(deviceinfo)
 
         # Check
-        assert "battery_level" not in device_data
-        assert "battery_low" not in device_data
+        assert devices == []
 
     def test_connection_timeout_passed_to_fritzconnection(self, mock_fritzconnection: MagicMock, caplog):
         # Prepare
@@ -1131,13 +1130,58 @@ class TestFritzDeviceAuthError:
         ) in caplog.record_tuples
 
 
-class TestParseAhaDeviceXml:
-    def test_should_return_empty_dict_on_parse_error(self):
+class TestParseAhaDevicelistXml:
+    def test_should_return_empty_list_on_parse_error(self):
         # Prepare
         invalid_xml = "this is not valid xml <<<"
 
         # Act
-        result = parse_aha_device_xml(invalid_xml)
+        result = parse_aha_devicelist_xml(invalid_xml)
 
         # Check
-        assert result == {}
+        assert result == []
+
+    def test_should_ignore_non_numeric_int_fields(self):
+        # Prepare
+        deviceinfo = """<?xml version="1.0" encoding="utf-8"?>
+        <devicelist version="1">
+        <device identifier="123456789012" id="123" functionbitmask="1"
+                fwversion="1.2" manufacturer="AVM" productname="Fritz!DECT 200">
+            <present>1</present>
+            <name>Fritz!DECT 200</name>
+            <battery>not-a-number</battery>
+        </device>
+        </devicelist>
+        """
+        # Act
+        devices = parse_aha_devicelist_xml(deviceinfo)
+
+        # Check
+        assert devices[0]["battery_level"] is None
+
+    def test_should_fall_back_to_hkr_battery_when_missing_on_device(self):
+        # Prepare - some firmware versions only report battery data nested
+        # inside <hkr> instead of as a direct child of <device>.
+        deviceinfo = """<?xml version="1.0" encoding="utf-8"?>
+        <devicelist version="1">
+        <device identifier="123456789012" id="123" functionbitmask="1"
+                fwversion="1.2" manufacturer="AVM" productname="Comet DECT">
+            <present>1</present>
+            <name>Comet DECT</name>
+            <hkr>
+                <tist>245</tist>
+                <tsoll>234</tsoll>
+                <absenk>234</absenk>
+                <komfort>234</komfort>
+                <battery>80</battery>
+                <batterylow>1</batterylow>
+            </hkr>
+        </device>
+        </devicelist>
+        """
+        # Act
+        devices = parse_aha_devicelist_xml(deviceinfo)
+
+        # Check
+        assert devices[0]["battery_level"] == 80
+        assert devices[0]["battery_low"] == "1"


### PR DESCRIPTION
## Summary

Fixes the slow home-automation (AHA) scrape reported in #310 (and discussed in #303) by replacing the current per-device call pattern with a single bulk HTTP call.

**Before:** for every home-automation device found, the exporter did one TR-064 `GetGenericDeviceInfos(NewIndex=i)` SOAP call (enumerated one index at a time until `FritzArrayIndexError`) *plus* one AHA HTTP `getdeviceinfos` call just to fetch battery data. Total: `2N + 1` requests per scrape (N = device count).

**After:** a single AHA HTTP `getdevicelistinfos` call returns presence, name, switch state, powermeter, temperature, HKR (thermostat) readings and battery data for *all* devices at once.

**Known gap:** `getdevicelistinfos` does not expose the per-setpoint valve/ventil status fields (`NewHkrSetVentilStatus`, `NewHkrReduceVentilStatus`, `NewHkrComfortVentilStatus`) that back `fritz_ha_heater_valve_set_state`, `fritz_ha_heater_reduced_valve_state`, and `fritz_ha_heater_comfort_valve_state`. To avoid dropping those metrics, the exporter still issues one supplemental TR-064 `GetSpecificDeviceInfos(NewAIN=...)` call per thermostat (looked up directly by AIN, not by re-enumerating indices). Net request count per scrape: `1 + N_thermostats`, down from `2·N_total + 1`.

Also fixes a unit bug uncovered while re-deriving the field mapping from the AHA HTTP schema: HKR temperatures (`tist`/`tsoll`/`absenk`/`komfort`) are in half-degree steps in this API, not tenths of a degree like the plain `<temperature>` element — the previous TR-064-only code path used `/10.0` uniformly; the new code uses `/2.0` for HKR fields specifically (verified against AVM's documented schema and the `pyfritzhome` reference implementation).

## Notes for review

- Neither of us has physical AHA/home-automation devices to test against a real FRITZ!Box (same limitation noted by @pdreker in #303) — real-hardware confirmation from a contributor with AHA devices (e.g. @r0ckarong, who reported #310) before merging would be valuable.
- `fritz_ha_device_present` can now only report `CONNECTED` (2) or `DISCONNECTED` (0) — the HTTP API's `<present>` is a plain boolean, so the TR-064-only `REGISTERED`/`UNKNOWN` states are no longer distinguishable.

## Test plan

- [x] Branch rebased onto latest `main` (includes #661-664)
- [x] `uv run pytest` — full suite passes (175 passed)
- [x] `uv run ruff check fritzexporter/` and `uv run ruff format --check fritzexporter/` — clean
- [x] `uv run ty check fritzexporter/` — no new diagnostics vs. `main` baseline
- [ ] Manual verification against a real FRITZ!Box with AHA devices (needs a contributor with such hardware)

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)