### PR TITLE
fix: skip empty-string Layer1 64-bit max bitrate on unsupported WAN types

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -71,6 +71,7 @@ Known Problems
 
 * It seems like Fritz!OS does not internally count the packets for the Guest WiFi. So even though those counters are there they are always 0. This seems to be a problem with Fritz!OS and not the exporter. The counters are delivered nontheless, just in case this gets fixed by AVM.
 * On multi-gig fibre (and possibly cable) links the classic ``fritz_wan_max_bitrate`` values from ``GetCommonLinkProperties`` can be wrong (often stuck at ``1000000``) because they use a 32-bit field. Prefer ``fritz_wan_layer1_max_bitrate_bps`` from ``GetAddonInfos``, which correctly reports e.g. 2.5 Gbit/s / 1.25 Gbit/s.
+* On WAN types that don't support the 64-bit Layer1 max bitrate fields (observed on cable), FRITZ!OS reports ``NewX_AVM_DE_Layer1DownstreamMaxBitRate64`` / ``NewX_AVM_DE_Layer1UpstreamMaxBitRate64`` as an empty string rather than omitting them or returning ``None``. The exporter treats this the same as "not provided" and simply omits ``fritz_wan_layer1_max_bitrate_bps`` for that direction/device — it does not indicate a fault, only that this WAN type doesn't expose the field.
 * Fibre / ``X_AVM-DE_WANFiber`` gaps observed on FRITZ!Box 5690 (Fritz!OS 8.25): the web UI shows real optical readings, but several TR-064 ``GetInfo`` / ``GetStatistics`` fields are empty or zero. The exporter still exposes the TR-064 values when present. The Fritz! team has been contacted about these issues:
 
   * ``NewOpticalSignalLevel`` / ``NewTransmitOpticalLevel`` stay at ``0`` while the UI shows real RX/TX power (e.g. about ``-19.5 dBm`` / ``2.4 dBm``)

--- a/fritzexporter/fritzcapabilities.py
+++ b/fritzexporter/fritzcapabilities.py
@@ -784,14 +784,19 @@ class WanCommonInterfaceByteRate(FritzCapability):
         )
 
         # Classic Layer1*MaxBitRate is ui4 and saturates/misreports on multi-gig links.
-        # Prefer the AVM 64-bit fields when the firmware provides them.
+        # Prefer the AVM 64-bit fields when the firmware provides them. On WAN
+        # types that don't support them (observed on cable), FRITZ!OS reports
+        # the field as an empty string rather than omitting it or returning
+        # None, which crashes exposition when Prometheus scrapes (the client
+        # library does float("") to format the sample) -- treat both as "not
+        # provided".
         layer1_rx = fritz_wan_result.get("NewX_AVM_DE_Layer1DownstreamMaxBitRate64")
         layer1_tx = fritz_wan_result.get("NewX_AVM_DE_Layer1UpstreamMaxBitRate64")
-        if layer1_rx is not None:
+        if layer1_rx not in (None, ""):
             self.metrics["layer1max"].add_metric(
                 [device.serial, device.friendly_name, "rx"], layer1_rx
             )
-        if layer1_tx is not None:
+        if layer1_tx not in (None, ""):
             self.metrics["layer1max"].add_metric(
                 [device.serial, device.friendly_name, "tx"], layer1_tx
             )

--- a/tests/test_fritzcapabilities.py
+++ b/tests/test_fritzcapabilities.py
@@ -568,3 +568,61 @@ class TestWanFiberCapabilities:
         assert layer1[
             (("direction", "tx"), ("friendly_name", "FritzFiber"), ("serial", "1234567890"))
         ] == 1250000000
+
+
+@patch("fritzexporter.tr064_remote.FritzConnection")
+class TestWanCommonInterfaceByteRateCableWan:
+    """Regression tests for WAN types (e.g. cable) that don't populate the
+    AVM 64-bit Layer1 max bitrate fields. FRITZ!OS reports them as an empty
+    string rather than omitting them or returning None in this case, which
+    previously crashed metric exposition (the client library does
+    float("") to format the sample value)."""
+
+    def test_empty_string_64bit_fields_are_skipped(self, mock_fritzconnection: MagicMock):
+        # Prepare - same as GetAddonInfos in fc_services_mock.py, except the
+        # two 64-bit fields come back as empty strings, as observed on a
+        # cable WAN connection.
+        fc = mock_fritzconnection.return_value
+
+        def call_action_cable_addon_infos(service, action, **kwargs):
+            if (service, action) == ("WANCommonIFC1", "GetAddonInfos"):
+                return {
+                    "NewByteReceiveRate": 12345,
+                    "NewByteSendRate": 23456,
+                    "NewX_AVM_DE_Layer1DownstreamMaxBitRate64": "",
+                    "NewX_AVM_DE_Layer1UpstreamMaxBitRate64": "",
+                }
+            return call_action_mock(service, action, **kwargs)
+
+        fc.call_action.side_effect = call_action_cable_addon_infos
+        fc.services = create_fc_services(
+            {
+                **fc_services_capabilities["DeviceInfo"],
+                **fc_services_capabilities["WanCommonInterfaceByteRate"],
+            }
+        )
+
+        collector = FritzCollector()
+        device = FritzDevice(
+            FritzCredentials("somehost", "someuser", "password"),
+            "FritzCable",
+            host_info=False,
+        )
+        collector.register(device)
+
+        # Act - this used to raise ValueError: could not convert string to
+        # float: '' while formatting the layer1max sample.
+        metrics: list[Metric] = list(collector.collect())
+
+        # Check - the field is silently skipped rather than emitted empty...
+        by_name = {m.name: m for m in metrics}
+        assert by_name["fritz_wan_layer1_max_bitrate_bps"].samples == []
+
+        # ...and the sibling byte-rate metric from the same call is unaffected.
+        byterate = _sample_map(by_name["fritz_wan_datarate_bytes"])
+        assert byterate[
+            (("direction", "rx"), ("friendly_name", "FritzCable"), ("serial", "1234567890"))
+        ] == 12345
+        assert byterate[
+            (("direction", "tx"), ("friendly_name", "FritzCable"), ("serial", "1234567890"))
+        ] == 23456


### PR DESCRIPTION
## Problem

On WAN types that don't support the AVM 64-bit Layer1 max-bitrate fields
(observed on a cable/DOCSIS connection), `WANCommonIFC1.GetAddonInfos`
returns `NewX_AVM_DE_Layer1DownstreamMaxBitRate64` /
`NewX_AVM_DE_Layer1UpstreamMaxBitRate64` as an empty string, rather than
omitting the field or returning `None`.

`WanCommonInterfaceByteRate._generate_metric_values` only guarded against
`None`, so the empty string was passed straight to `add_metric()`. The
Prometheus client does `float(value)` when formatting the sample, and
`float("")` raises `ValueError`, crashing exposition for the *entire*
`/metrics` endpoint — not just this one metric.

## Fix

Treat both `None` and `""` as "not provided" and skip the metric in that
case, for both the RX and TX guards.

## Docs

Added a note to the `Known Problems` section (next to the existing
Layer1 max-bitrate entry) explaining that the metric will simply be
absent on WAN types like cable, since this is a FRITZ!OS quirk and not
a bug in the exporter.

## AI assistance disclaimer

This fix, its regression test, and the accompanying docs update were
crafted with the help of AI (Claude Sonnet 5, Anthropic), under my
review and direction. All commits are attributed to me as author, with
Claude Sonnet 5 as co-author.

## Testing

- Added `TestWanCommonInterfaceByteRateCableWan` in
  `tests/test_fritzcapabilities.py`, mocking the empty-string response
  and asserting `fritz_wan_layer1_max_bitrate_bps` is skipped while the
  sibling `fritz_wan_datarate_bytes` metric from the same call is
  unaffected.
- Confirmed the new test fails without the fix
  (`ValueError: could not convert string to float: ''`) and passes with it.
- Full suite: `uv run pytest` (172 passed), `uv run ruff check .`,
  `uv run ruff format --check .`, `uv run ty check` — all clean.