### PR TITLE
test: add exposition smoke test, fix misleading #668 comment

### DIFF
--- a/tests/test_fritzcapabilities.py
+++ b/tests/test_fritzcapabilities.py
@@ -9,6 +9,7 @@ from fritzconnection.core.exceptions import (
     FritzHttpInterfaceError,
     FritzServiceError,
 )
+from prometheus_client import CollectorRegistry, generate_latest
 from prometheus_client.core import Metric
 
 from fritzexporter.fritzdevice import FritzCollector, FritzCredentials, FritzDevice
@@ -638,8 +639,7 @@ class TestWanCommonInterfaceByteRateCableWan:
         )
         collector.register(device)
 
-        # Act - this used to raise ValueError: could not convert string to
-        # float: '' while formatting the layer1max sample.
+        # Act
         metrics: list[Metric] = list(collector.collect())
 
         # Check - the field is silently skipped rather than emitted empty...
@@ -654,3 +654,12 @@ class TestWanCommonInterfaceByteRateCableWan:
         assert byterate[
             (("direction", "tx"), ("friendly_name", "FritzCable"), ("serial", "1234567890"))
         ] == 23456
+
+        # ...and, crucially, rendering the actual exposition text does not
+        # raise. add_metric() stores a value as-is with no conversion, so
+        # asserting on samples alone (above) does NOT prove the ValueError
+        # this regression is named after is actually fixed - only rendering
+        # does, since that's where floatToGoString() calls float(value).
+        registry = CollectorRegistry()
+        registry.register(collector)
+        generate_latest(registry)

--- a/tests/test_fritzdevice.py
+++ b/tests/test_fritzdevice.py
@@ -9,6 +9,7 @@ from fritzconnection.core.exceptions import (
     FritzConnectionException,
     FritzServiceError,
 )
+from prometheus_client import CollectorRegistry, generate_latest
 from prometheus_client.core import Metric
 
 from fritzexporter.exceptions import FritzDeviceHasNoCapabilitiesError
@@ -370,6 +371,36 @@ class TestFritzCollector:
                 assert s.labels["serial"] == "1234567890"
                 assert "friendly_name" in s.labels
                 assert s.labels["friendly_name"] == "FritzMock"
+
+    def test_should_render_full_exposition_without_raising(
+        self, mock_fritzconnection: MagicMock, caplog
+    ):
+        # Prepare - a full-fixture device exercising every capability, fed
+        # through the actual Prometheus text-exposition formatter. Unlike
+        # every other test here (which only inspects the collect() Metric/
+        # Sample objects), this is the one place that renders exposition
+        # text: add_metric() stores a value as-is with no conversion, and
+        # a non-numeric value (see #668/#669) only blows up later, inside
+        # generate_latest()'s float() formatting - so only rendering can
+        # actually catch that class of bug.
+        caplog.set_level(logging.DEBUG)
+
+        fc = mock_fritzconnection.return_value
+        fc.call_action.side_effect = call_action_mock
+        fc.call_http.side_effect = call_http_mock
+        fc.services = create_fc_services(fc_services_devices["FritzBox 7590"])
+
+        collector = FritzCollector()
+        device = FritzDevice(FritzCredentials("somehost", "someuser", "password"), "FritzMock", host_info=False)
+        collector.register(device)
+
+        registry = CollectorRegistry()
+        registry.register(collector)
+
+        # Act / Check - must not raise
+        output = generate_latest(registry)
+
+        assert b"fritz_uptime_seconds" in output
 
     def test_should_collect_host_info_from_device(self, mock_fritzconnection: MagicMock, caplog):
         # Prepare


### PR DESCRIPTION
## Summary

- Adds a general smoke test (`test_should_render_full_exposition_without_raising` in `tests/test_fritzdevice.py`) that registers a full-fixture `FritzCollector` with a real `CollectorRegistry` and calls `generate_latest()`, asserting it doesn't raise. This closes #669: every other test in the suite only inspects `collect()`'s `Metric`/`Sample` objects, so a malformed value reaching `add_metric()` (as happened in #668) was invisible until it actually hit real Prometheus exposition formatting.
- Fixes the misleading comment on the #668 regression test (`TestWanCommonInterfaceByteRateCableWan.test_empty_string_64bit_fields_are_skipped`), which claimed it reproduced `ValueError: could not convert string to float: ''` but only asserted on sample presence/absence. It now also calls `generate_latest()` at the end, so the comment is actually true for that test.

## Verification

- Manually reverted the #668 fix and confirmed both new/updated tests fail without it (the CableWan test fails on the sample assertion as before; standalone verification confirmed `generate_latest()` on the pre-fix code raises the exact `ValueError` described).
- `uv run pytest` — 177 passed (was 175 before this PR).
- `uv run ruff check fritzexporter/`, `uv run ruff format --check fritzexporter/`, `uv run ty check fritzexporter/` — all clean.

Closes #669

🤖 Generated with [Claude Code](https://claude.com/claude-code)